### PR TITLE
feat: Added initial implementation of ajvResolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@types/yup": "^0.29.3",
     "@typescript-eslint/eslint-plugin": "^3.2.0",
     "@typescript-eslint/parser": "^3.2.0",
+    "ajv": "^6.12.2",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.4",

--- a/src/__snapshots__/ajv.test.ts.snap
+++ b/src/__snapshots__/ajv.test.ts.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ajvResolver using Ajv.compile should get errors for array fields 1`] = `
+Object {
+  "errors": Object {
+    "hobbies[0].description": Object {
+      "message": "should NOT be shorter than 3 characters",
+      "params": Object {
+        "limit": 3,
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvResolver using Ajv.compile should get errors for top level properties 1`] = `
+Object {
+  "errors": Object {
+    "age": Object {
+      "message": "should be integer",
+      "params": Object {
+        "type": "integer",
+      },
+    },
+    "email": Object {
+      "message": "should match format \\"email\\"",
+      "params": Object {
+        "format": "email",
+      },
+    },
+    "name": Object {
+      "message": "should NOT be shorter than 3 characters",
+      "params": Object {
+        "limit": 3,
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvResolver using Ajv.validate should get errors for array fields 1`] = `
+Object {
+  "errors": Object {
+    "hobbies[0].description": Object {
+      "message": "should NOT be shorter than 3 characters",
+      "params": Object {
+        "limit": 3,
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvResolver using Ajv.validate should get errors for top level properties 1`] = `
+Object {
+  "errors": Object {
+    "age": Object {
+      "message": "should be integer",
+      "params": Object {
+        "type": "integer",
+      },
+    },
+    "email": Object {
+      "message": "should match format \\"email\\"",
+      "params": Object {
+        "format": "email",
+      },
+    },
+    "name": Object {
+      "message": "should NOT be shorter than 3 characters",
+      "params": Object {
+        "limit": 3,
+      },
+    },
+  },
+  "values": Object {},
+}
+`;

--- a/src/ajv.test.ts
+++ b/src/ajv.test.ts
@@ -1,0 +1,159 @@
+import * as Ajv from 'ajv';
+import { ajvResolver } from './ajv';
+
+const schema = {
+  $async: true,
+  type: 'object',
+  properties: {
+    name: {
+      type: 'string',
+      pattern: '[a-zA-Z]',
+      minLength: 3,
+    },
+    age: {
+      type: 'integer',
+      minimum: 0,
+    },
+    email: {
+      type: 'string',
+      format: 'email',
+    },
+    hobbies: {
+      type: 'array',
+      minItems: 1,
+      items: {
+        properties: {
+          description: {
+            type: 'string',
+            minLength: 3,
+          },
+        },
+        required: ['description'],
+      },
+    },
+  },
+  required: ['name', 'age', 'email', 'hobbies'],
+};
+
+describe('ajvResolver', () => {
+  describe('using Ajv.compile', () => {
+    let validate: any;
+
+    beforeEach(() => {
+      validate = new Ajv({ allErrors: true, coerceTypes: true }).compile(
+        schema,
+      );
+    });
+
+    it('should get values', async () => {
+      const data = {
+        name: 'jimmy',
+        age: '24',
+        email: 'jimmy@jimmy.com',
+        hobbies: ['tennis'],
+      };
+
+      expect(await ajvResolver(validate)(data)).toEqual({
+        errors: {},
+        values: data,
+      });
+    });
+
+    it('should get errors for array fields', async () => {
+      const data = {
+        name: 'jimmy',
+        age: 24,
+        email: 'jimmy@jimmy.com',
+        hobbies: [
+          {
+            description: '',
+          },
+        ],
+      };
+      expect(await ajvResolver(validate)(data)).toMatchSnapshot();
+    });
+
+    it('should get errors for top level properties', async () => {
+      const data = {
+        name: 24,
+        age: 'jimmy',
+        email: 'jimmyjimmy.com',
+        hobbies: [
+          {
+            description: 'Tennis',
+          },
+        ],
+      };
+
+      expect(await ajvResolver(validate)(data)).toMatchSnapshot();
+    });
+
+    it('should return empty object when validate pass', async () => {
+      expect(
+        await ajvResolver({
+          validate: () => new Promise((resolve) => resolve()) as any,
+        })({}),
+      ).toEqual({ errors: {}, values: {} });
+    });
+  });
+
+  describe('using Ajv.validate', () => {
+    let validate: any;
+
+    beforeEach(() => {
+      const ajv = new Ajv({ allErrors: true, coerceTypes: true });
+      validate = (data: any) => ajv.validate(schema, data);
+    });
+
+    it('should get values', async () => {
+      const data = {
+        name: 'jimmy',
+        age: '24',
+        email: 'jimmy@jimmy.com',
+        hobbies: ['tennis'],
+      };
+
+      expect(await ajvResolver(validate)(data)).toEqual({
+        errors: {},
+        values: data,
+      });
+    });
+
+    it('should get errors for array fields', async () => {
+      const data = {
+        name: 'jimmy',
+        age: 24,
+        email: 'jimmy@jimmy.com',
+        hobbies: [
+          {
+            description: '',
+          },
+        ],
+      };
+      expect(await ajvResolver(validate)(data)).toMatchSnapshot();
+    });
+
+    it('should get errors for top level properties', async () => {
+      const data = {
+        name: 24,
+        age: 'jimmy',
+        email: 'jimmyjimmy.com',
+        hobbies: [
+          {
+            description: 'Tennis',
+          },
+        ],
+      };
+
+      expect(await ajvResolver(validate)(data)).toMatchSnapshot();
+    });
+
+    it('should return empty object when validate pass', async () => {
+      expect(
+        await ajvResolver({
+          validate: () => new Promise((resolve) => resolve()) as any,
+        })({}),
+      ).toEqual({ errors: {}, values: {} });
+    });
+  });
+});

--- a/src/ajv.ts
+++ b/src/ajv.ts
@@ -1,0 +1,78 @@
+import { appendErrors } from 'react-hook-form';
+import { ValidationError, ValidateFunction } from 'ajv';
+
+type FieldValues = Record<string, any>;
+
+const parseErrorSchema = (
+  validationError: ValidationError,
+  validateAllFieldCriteria: boolean,
+) =>
+  Array.isArray(validationError.errors)
+    ? validationError.errors.reduce(
+        (
+          previous: FieldValues,
+          { dataPath, message = '', params, propertyName = '' },
+        ) => {
+          const path =
+            dataPath.replace(/\//g, '.').replace(/^\./, '') || propertyName;
+          return {
+            ...previous,
+            ...(path
+              ? previous[path] && validateAllFieldCriteria
+                ? {
+                    [path]: appendErrors(
+                      path,
+                      validateAllFieldCriteria,
+                      previous,
+                      '',
+                      message,
+                    ),
+                  }
+                : {
+                    [path]: previous[path] || {
+                      message,
+                      params,
+                      ...(validateAllFieldCriteria
+                        ? {
+                            types: {
+                              ['']: message || true,
+                            },
+                          }
+                        : {}),
+                    },
+                  }
+              : {}),
+          };
+        },
+        {},
+      )
+    : [];
+
+interface schema {
+  validate: ValidateFunction;
+}
+
+export const ajvResolver = (validationSchema: schema | ValidateFunction) => {
+  const validate =
+    typeof (validationSchema as schema)?.validate === 'function'
+      ? (validationSchema as schema).validate
+      : typeof validationSchema === 'function'
+      ? validationSchema
+      : undefined;
+
+  if (!validate) {
+    throw new Error('Invalid AJV validate function');
+  }
+
+  return async (data: any, _: any = {}, validateAllFieldCriteria = false) => {
+    try {
+      await validate(data);
+      return { values: data, errors: {} };
+    } catch (e) {
+      return {
+        values: {},
+        errors: parseErrorSchema(e, validateAllFieldCriteria),
+      };
+    }
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -787,7 +787,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
   integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==


### PR DESCRIPTION
AJV's validation API is a little clunky with a few different ways to use it and no real normalisation (some times it throws an exception and other times it sets the errors on what should ideally be an immutable object).

Currently only supports $async schemas, but this is easy to append to any JSON schema so deemed a suitable trade off as an initial version and this supports all use cases, be that local, in-memory validation (sync or async) or asynchronous validation via a remote call.

