### PR TITLE
Fix jsnext:main entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "umd:main": "dist/index.umd.min.js",
   "unpkg": "dist/index.umd.min.js",
   "jsdelivr": "dist/index.umd.min.js",
-  "jsnext:main": "index.esm.js",
+  "jsnext:main": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Prepend `dist/` directory to jsnext:main entry point