### PR TITLE
Support multiple errors messages

### DIFF
--- a/src/__snapshots__/yup.test.ts.snap
+++ b/src/__snapshots__/yup.test.ts.snap
@@ -6,26 +6,42 @@ Object {
     "age": Object {
       "message": "age is a required field",
       "type": "required",
+      "types": Object {
+        "required": "age is a required field",
+      },
     },
     "name": Object {
       "message": "name is a required field",
       "type": "required",
+      "types": Object {
+        "min": "name is a min field",
+      },
     },
   },
   "values": Object {},
 }
 `;
 
-exports[`yupResolver should get errors 1`] = `
+exports[`yupResolver errors should get errors with validate all criteria fields 1`] = `
 Object {
   "errors": Object {
     "age": Object {
       "message": "age must be a \`number\` type, but the final value was: \`NaN\` (cast from the value \`\\"test\\"\`).",
       "type": "typeError",
+      "types": Object {
+        "typeError": Array [
+          "age must be a \`number\` type, but the final value was: \`NaN\` (cast from the value \`\\"test\\"\`).",
+        ],
+      },
     },
     "createdOn": Object {
       "message": "createdOn must be a \`date\` type, but the final value was: \`Invalid Date\`.",
       "type": "typeError",
+      "types": Object {
+        "typeError": Array [
+          "createdOn must be a \`date\` type, but the final value was: \`Invalid Date\`.",
+        ],
+      },
     },
     "foo": Array [
       Object {
@@ -33,9 +49,75 @@ Object {
           "message": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
  If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
           "type": "typeError",
+          "types": Object {
+            "typeError": Array [
+              "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
+ If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
+            ],
+          },
         },
       },
     ],
+    "password": Object {
+      "message": "password is a required field",
+      "type": "required",
+      "types": Object {
+        "matches": Array [
+          "Special",
+          "Number",
+          "Uppercase",
+          "Lowercase",
+        ],
+        "min": Array [
+          "password must be at least 8 characters",
+        ],
+        "required": Array [
+          "password is a required field",
+        ],
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`yupResolver errors should get errors without validate all criteria fields 1`] = `
+Object {
+  "errors": Object {
+    "age": Object {
+      "message": "age must be a \`number\` type, but the final value was: \`NaN\` (cast from the value \`\\"test\\"\`).",
+      "type": "typeError",
+      "types": Object {
+        "typeError": "age must be a \`number\` type, but the final value was: \`NaN\` (cast from the value \`\\"test\\"\`).",
+      },
+    },
+    "createdOn": Object {
+      "message": "createdOn must be a \`date\` type, but the final value was: \`Invalid Date\`.",
+      "type": "typeError",
+      "types": Object {
+        "typeError": "createdOn must be a \`date\` type, but the final value was: \`Invalid Date\`.",
+      },
+    },
+    "foo": Array [
+      Object {
+        "loose": Object {
+          "message": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
+ If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
+          "type": "typeError",
+          "types": Object {
+            "typeError": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
+ If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
+          },
+        },
+      },
+    ],
+    "password": Object {
+      "message": "password is a required field",
+      "type": "required",
+      "types": Object {
+        "required": "password is a required field",
+      },
+    },
   },
   "values": Object {},
 }

--- a/src/__snapshots__/yup.test.ts.snap
+++ b/src/__snapshots__/yup.test.ts.snap
@@ -33,19 +33,15 @@ Object {
         "typeError": "createdOn must be a \`date\` type, but the final value was: \`Invalid Date\`.",
       },
     },
-    "foo": Array [
-      Object {
-        "loose": Object {
-          "message": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
+    "foo[0].loose": Object {
+      "message": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
  If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
-          "type": "typeError",
-          "types": Object {
-            "typeError": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
+      "type": "typeError",
+      "types": Object {
+        "typeError": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
  If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
-          },
-        },
       },
-    ],
+    },
     "password": Object {
       "message": "password is a required field",
       "type": "required",

--- a/src/yup.test.ts
+++ b/src/yup.test.ts
@@ -99,6 +99,13 @@ describe('yupResolver', () => {
       };
       const resolve = await yupResolver(schema)(data, {}, true);
       expect(resolve).toMatchSnapshot();
+      expect(resolve.errors['foo[0].loose']).toBeDefined();
+      expect(resolve.errors['foo[0].loose'].types).toMatchInlineSnapshot(`
+        Object {
+          "typeError": "foo[0].loose must be a \`boolean\` type, but the final value was: \`null\`.
+         If \\"null\\" is intended as an empty value be sure to mark the schema as \`.nullable()\`",
+        }
+      `);
       expect(resolve.errors.age.types).toMatchInlineSnapshot(`
         Object {
           "typeError": "age must be a \`number\` type, but the final value was: \`NaN\` (cast from the value \`\\"test\\"\`).",
@@ -132,6 +139,7 @@ describe('yupResolver', () => {
       };
       const resolve = await yupResolver(schema)(data);
       expect(await yupResolver(schema)(data)).toMatchSnapshot();
+      expect(resolve.errors['foo[0].loose']).toBeUndefined();
       expect(resolve.errors.age.types).toBeUndefined();
       expect(resolve.errors.createdOn.types).toBeUndefined();
       expect(resolve.errors.password.types).toBeUndefined();

--- a/src/yup.test.ts
+++ b/src/yup.test.ts
@@ -238,6 +238,9 @@ describe('validateWithSchema', () => {
           "name": Object {
             "message": "name must be at least 6 characters",
             "type": "min",
+            "types": Object {
+              "min": "name must be at least 6 characters",
+            },
           },
         },
         "values": Object {},

--- a/src/yup.ts
+++ b/src/yup.ts
@@ -1,43 +1,44 @@
-import { appendErrors, transformToNestObject, Resolver } from 'react-hook-form';
+import { Resolver, transformToNestObject } from 'react-hook-form';
+import { FieldError, FieldErrors } from 'react-hook-form/dist/types/form';
+import { DeepMap } from 'react-hook-form/dist/types/utils';
 import Yup from 'yup';
 
-const parseErrorSchema = (
+const parseErrorSchema = <TFieldValues extends Record<string, any>>(
   error: Yup.ValidationError,
   validateAllFieldCriteria: boolean,
-) =>
-  Array.isArray(error.inner)
-    ? error.inner.reduce(
-        (previous: Record<string, any>, { path, message, type }) => ({
-          ...previous,
-          ...(path
-            ? previous[path] && validateAllFieldCriteria
-              ? {
-                  [path]: appendErrors(
-                    path,
-                    validateAllFieldCriteria,
-                    previous,
-                    type,
-                    message,
-                  ),
-                }
-              : {
-                  [path]: previous[path] || {
-                    message,
-                    type,
-                    ...(validateAllFieldCriteria
-                      ? {
-                          types: { [type]: message || true },
-                        }
-                      : {}),
-                  },
-                }
-            : {}),
-        }),
+): DeepMap<TFieldValues, FieldError> =>
+  Array.isArray(error.inner) && error.inner.length
+    ? error.inner.reduce<FieldErrors<TFieldValues>>(
+        (previous, { path, message, type }) => {
+          const previousPath = previous[path] as FieldErrors | undefined;
+          const previousTypes = validateAllFieldCriteria
+            ? previousPath?.types || []
+            : {};
+          return {
+            ...previous,
+            [path]: {
+              ...(previous[path] || {
+                message,
+                type,
+                types: previousTypes,
+              }),
+              types: {
+                ...previousTypes,
+                [type]: validateAllFieldCriteria
+                  ? [message, ...(previousTypes[type] || [])]
+                  : message,
+              },
+            },
+          };
+        },
         {},
       )
-    : {
-        [error.path]: { message: error.message, type: error.type },
-      };
+    : ({
+        [error.path]: {
+          message: error.message,
+          type: error.type,
+        },
+      } as DeepMap<TFieldValues, FieldError>);
 
 export const yupResolver = <TFieldValues extends Record<string, any>>(
   schema: Yup.ObjectSchema | Yup.Lazy,

--- a/src/yup.ts
+++ b/src/yup.ts
@@ -58,11 +58,12 @@ export const yupResolver = <TFieldValues extends Record<string, any>>(
       errors: {},
     };
   } catch (e) {
+    const parsedErrors = parseErrorSchema(e, validateAllFieldCriteria);
     return {
       values: {},
-      errors: transformToNestObject(
-        parseErrorSchema(e, validateAllFieldCriteria),
-      ),
+      errors: validateAllFieldCriteria
+        ? parsedErrors
+        : transformToNestObject(parsedErrors),
     };
   }
 };

--- a/src/yup.ts
+++ b/src/yup.ts
@@ -41,7 +41,7 @@ const parseErrorSchema = (
 
 export const yupResolver = <TFieldValues extends Record<string, any>>(
   schema: Yup.ObjectSchema | Yup.Lazy,
-  options: Yup.ValidateOptions = {
+  options: Omit<Yup.ValidateOptions, 'context'> = {
     abortEarly: false,
   },
 ): Resolver<TFieldValues> => async (
@@ -50,10 +50,19 @@ export const yupResolver = <TFieldValues extends Record<string, any>>(
   validateAllFieldCriteria = false,
 ) => {
   try {
+    if (
+      (options as Yup.ValidateOptions).context &&
+      process.env.NODE_ENV === 'development'
+    ) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "You should not used the yup options context. Please, use the 'useForm' context object instead",
+      );
+    }
     return {
       values: (await schema.validate(values, {
-        context,
         ...options,
+        context,
       })) as any,
       errors: {},
     };


### PR DESCRIPTION
- [x] 100% test coverage for the yup resolver
- [x] Now errors have a types props with a Record key type and for values an array of error messages, if `criteriaMode: "all"` 

**At the same time:** 
- [x] Fix the abort early issue. It does not work because it let a yup resolver with an `inner error` of an empty array. So it always return any errors. Now we check if inner errors is an empty array or not. If no please return only one error at a time. Test has been done for this. it could help resolve issue from -> https://github.com/react-hook-form/resolvers/pull/30#issuecomment-660380652 where yup validation return anything.
- [x] Optimise the validate all field criteria props in the yup resolver script. The yup error path is always defined so i remove some useless code logic ( if i don't make a mistake )
- [x] The new props `types` is always defined it can be an empty array too.
- [x] Still compatible with the ErrorMessage component. 
- [x] Add more types to the resolver script -> to be check im not an expert. I used types from rhf dist i think maybe it is not the right way :/

**Improvements which can be done into**

1.  For an array, If we remove the `transformToNestObject` we will have at the same time array errors and all field errors inside this array.
Cons: errors duplication : 
```
foo[0].test: {
      message: ...,
      type: ...,
      types: [ ] | {}
},
foo: [
  { 
    test: {
      message: ...,
      type: ...,
      types: [ ] | {}
    }
  },
  ...
]
```
Pros: it can be interesting to have it to get at the same time array errors and fields errors in.
We could maybe do : `validateAllFieldCriteria ? call transformToNestObject `
You can have example of use case here -> https://github.com/react-hook-form/resolvers/issues/26#issuecomment-660498288
From issue -> https://github.com/react-hook-form/resolvers/issues/26

2. On first try to rhf we don't know where to place the context and where will be the changes !? We should remove the context option from the yup options by his types. It come in trouble when you expect your form validation to be used from cached context or from yup context options. From my issue -> https://github.com/react-hook-form/react-hook-form/issues/2222. We could do this to force user to always use the context manage by rhf:
```
export const yupResolver = <TFieldValues extends Record<string, any>>(
  schema: Yup.ObjectSchema | Yup.Lazy,
  options: Omit<Yup.ValidateOptions, 'context'> = { // OMIT THE CONTEXT
    abortEarly: false,
  },
```

it could help issue like -> https://github.com/react-hook-form/resolvers/pull/30#issuecomment-660380652