### PR TITLE
improve rollup config to support IE11

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -38,6 +38,14 @@ const options = [
     env: 'production',
     input: pkg.source,
   },
+  {
+    name,
+    umdName,
+    format: 'esm',
+    formatName: 'ie11',
+    input: pkg.source,
+    tsconfig: './tsconfig.ie11.json',
+  },
 ];
 
 export default options.map((option) => createRollupConfig(option));

--- a/rollup/createRollupConfig.js
+++ b/rollup/createRollupConfig.js
@@ -12,7 +12,7 @@ import { safePackageName } from './safePackageName';
 import { pascalcase } from './pascalcase';
 import pkg from '../package.json';
 
-export function createRollupConfig(options) {
+export function createRollupConfig(options, callback) {
   const name = options.name || safePackageName(pkg.name);
   const umdName = options.umdName || pascalcase(safePackageName(pkg.name));
   const shouldMinify = options.minify || options.env === 'production';
@@ -34,7 +34,7 @@ export function createRollupConfig(options) {
     .filter(Boolean)
     .join('.');
 
-  return {
+  const config = {
     input: options.input,
     output: {
       file: outputName,
@@ -72,7 +72,8 @@ export function createRollupConfig(options) {
             drop_console: true,
           },
         }),
-      options.plugins,
-    ],
+    ].filter(Boolean),
   };
+
+  return callback ? callback(config) : config;
 }

--- a/tsconfig.ie11.json
+++ b/tsconfig.ie11.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "target": "es5",
+    "downlevelIteration": true
+  }
+}


### PR DESCRIPTION
Usage:

```ts
import { yupResolver } from '@hookform/resolvers/dist/index.ie11.js';
```

if using TS:

create declaration file (`.d.ts`).

```ts
// global.d.ts
declare module '@hookform/resolvers/dist/index.ie11.js' {
    export * from '@hookform/resolvers';
}
```

if using webpack:

Note: not neeed to create declaration file if using TS.

```ts
import { yupResolver } from '@hookform/resolvers';
```

```js
// webpack.config.js
resolve: {
  alias: {
    "@hookform/resolvers": "@hookform/resolvers/dist/index.ie11.js"
  }
}
```

close #42
related https://github.com/react-hook-form/resolvers/pull/40