### PR TITLE
Use right version of react-hook-form for ie11 bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,7 @@
   "scripts": {
     "clean": "rimraf dist",
     "prebuild": "npm run clean",
-    "build": "run-p bundle bundle:ie11 bundle:umd",
-    "bundle": "tsc",
-    "bundle:ie11": "tsc --outDir dist/ie11 --downlevelIteration --target es5",
-    "bundle:umd": "rollup -c",
+    "build": "tsc && rollup -c",
     "lint": "eslint '**/*.{js,ts}'",
     "lint:fix": "npm run lint -- --fix",
     "lint:types": "tsc --noEmit",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "husky": "^4.2.5",
     "jest": "^26.0.1",
     "lint-staged": "^10.2.10",
+    "matched": "^5.0.0",
     "npm-run-all": "^4.1.5",
     "prettier": "^2.0.5",
     "react": "^16.13.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,43 +1,4 @@
-import typescript from 'rollup-plugin-typescript2';
-import { terser } from 'rollup-plugin-terser';
-import resolve from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
+import umd from './rollup/umd';
+import cjsie11 from './rollup/cjs.ie11';
 
-const dir = './dist/umd';
-
-export default {
-  input: './src/index.ts',
-  output: {
-    dir,
-    name: 'ReactHookFormResolvers',
-    format: 'umd',
-    sourcemap: true,
-    globals: {
-      'react-hook-form': 'ReactHookForm',
-    },
-    exports: 'named',
-  },
-  external: ['react-hook-form'],
-  plugins: [
-    typescript({
-      clean: true,
-      tsconfigOverride: {
-        compilerOptions: { declaration: false, module: 'ESNext' },
-      },
-    }),
-    resolve({
-      customResolveOptions: {
-        moduleDirectory: dir,
-      },
-    }),
-    commonjs({
-      include: /\/node_modules\//,
-    }),
-    terser({
-      output: { comments: false },
-      compress: {
-        drop_console: true,
-      },
-    }),
-  ],
-};
+export default [umd, cjsie11];

--- a/rollup/cjs.ie11.js
+++ b/rollup/cjs.ie11.js
@@ -1,0 +1,34 @@
+import glob from 'matched';
+import commonjs from '@rollup/plugin-commonjs';
+import typescript from 'rollup-plugin-typescript2';
+import mergeConfig from './merge-config';
+
+const dir = './dist/ie11';
+
+const config = {
+  input: glob.sync(['src/**/*.ts', '!src/index.ts', '!src/**/*.test.ts']),
+  preserveModules: true,
+  output: {
+    dir,
+    format: 'cjs',
+    paths: {
+      'react-hook-form': 'react-hook-form/dist/index.ie11',
+    },
+  },
+  plugins: [
+    commonjs(),
+    typescript({
+      clean: true,
+      tsconfigOverride: {
+        compilerOptions: {
+          declaration: false,
+          module: 'ESNext',
+          downlevelIteration: true,
+          target: 'es5',
+        },
+      },
+    }),
+  ],
+};
+
+export default mergeConfig(config);

--- a/rollup/merge-config.js
+++ b/rollup/merge-config.js
@@ -1,0 +1,32 @@
+import { terser } from 'rollup-plugin-terser';
+import resolve from '@rollup/plugin-node-resolve';
+
+/**
+ * Merge rollup config with base config
+ * @param {*} config
+ */
+export default function mergeRollupConfig(config) {
+  return {
+    ...config,
+    external: ['react-hook-form'],
+    output: {
+      sourcemap: true,
+      exports: 'named',
+      ...config.output,
+    },
+    plugins: [
+      resolve({
+        customResolveOptions: {
+          moduleDirectory: config.output.dir,
+        },
+      }),
+      terser({
+        output: { comments: false },
+        compress: {
+          drop_console: true,
+        },
+      }),
+      ...config.plugins,
+    ],
+  };
+}

--- a/rollup/umd.js
+++ b/rollup/umd.js
@@ -1,0 +1,26 @@
+import typescript from 'rollup-plugin-typescript2';
+import mergeConfig from './merge-config';
+
+const dir = './dist/umd';
+
+const config = {
+  input: './src/index.ts',
+  output: {
+    dir,
+    name: 'ReactHookFormResolvers',
+    format: 'umd',
+    globals: {
+      'react-hook-form': 'ReactHookForm',
+    },
+  },
+  plugins: [
+    typescript({
+      clean: true,
+      tsconfigOverride: {
+        compilerOptions: { declaration: false, module: 'ESNext' },
+      },
+    }),
+  ],
+};
+
+export default mergeConfig(config);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3184,6 +3184,14 @@ map-visit@^1.0.0:
   dependencies:
     object-visit "^1.0.0"
 
+matched@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/matched/-/matched-5.0.0.tgz#4b10735a89f87b6f9bf457136472631e19df05d7"
+  integrity sha512-O0LCuxYYBNBjP2dmAg0i6PME0Mb0dvjulpMC0tTIeMRh6kXYsugOT5GOWpFkSzqjQjgOUs/eiyvpVhXdN2La4g==
+  dependencies:
+    glob "^7.1.6"
+    picomatch "^2.2.1"
+
 memorystream@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/memorystream/-/memorystream-0.3.1.tgz#86d7090b30ce455d63fbae12dda51a47ddcaf9b2"
@@ -3604,7 +3612,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.2:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1, picomatch@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==


### PR DESCRIPTION
👋🏻 

Related to https://github.com/react-hook-form/resolvers/issues/64

Use rollup instead of tsc to bundle ie11.

`paths` allow to rewrite import in order to use the right version of react-hook-form and then fix the issue.
```js
paths: {
  'react-hook-form': 'react-hook-form/dist/index.ie11',
},
```