### PR TITLE
Add TS declaration files to ie11 build

### DIFF
--- a/rollup/cjs.ie11.js
+++ b/rollup/cjs.ie11.js
@@ -21,7 +21,7 @@ const config = {
       clean: true,
       tsconfigOverride: {
         compilerOptions: {
-          declaration: false,
+          declaration: true,
           module: 'ESNext',
           downlevelIteration: true,
           target: 'es5',


### PR DESCRIPTION
👋🏻 

Related to https://github.com/react-hook-form/resolvers/issues/64#issuecomment-717076880, workaround: https://github.com/react-hook-form/resolvers/issues/64#issuecomment-716614092

Allow to generate TS declaration files for ie11 build which produce the following result and no more workaround needed :)
![Screen Shot 2020-11-06 at 23 03 34](https://user-images.githubusercontent.com/7545547/98419042-7ffd2300-2084-11eb-912a-47b1cf07914d.png)
