### PR TITLE
Fixing and standardizing Zod example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,29 +74,36 @@ TypeScript-first schema validation with static type inference
 
 [![npm](https://img.shields.io/bundlephobia/minzip/zod?style=for-the-badge)](https://bundlephobia.com/result?p=zod)
 
-```typescript jsx
+> ⚠️ Example below uses the `valueAsNumber`, which requires `react-hook-form` v6.12.0 (released Nov 28, 2020) or later.
+
+```tsx
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 
 const schema = z.object({
-  username: z.string(),
+  name: z.string().nonempty({ message: 'Required' }),
+  age: z.number().min(10),
 });
 
 const App = () => {
-  const { register, handleSubmit } = useForm({
+  const { register, handleSubmit, errors } = useForm({
     resolver: zodResolver(schema),
   });
 
   return (
     <form onSubmit={handleSubmit((d) => console.log(d))}>
       <input name="name" ref={register} />
-      <input name="age" type="number" ref={register} />
+      {errors.name?.message && <p>{errors.name?.message}</p>}
+      <input name="age" type="number" ref={register({ valueAsNumber: true })} />
+      {errors.age?.message && <p>{errors.age?.message}</p>}
       <input type="submit" />
     </form>
   );
 };
+
+export default App;
 ```
 
 ### [Superstruct](https://github.com/ianstormtaylor/superstruct)

--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
   },
   globals: {
     'ts-jest': {
-      tsConfig: 'tsconfig.jest.json',
+      tsconfig: 'tsconfig.jest.json',
     },
   },
   testMatch: ['**/?(*.)+(spec|test).ts?(x)'],


### PR DESCRIPTION
For some reason the Zod example implemented a different form from the other 3 examples, so I decided to standardize it wiht the others. In the process of doing that I realized the sample was buggy because the Zod schema didn't convert the `age` string into a number. This makes sense because Zod v1 (which the author of the resolver was using) didn't support value transformations. I was planning to upgrade the example to use Zod 2 (which is capable of converting the string to a number) but then I saw that support for `valueAsNumber` was just introduced! Which is SUCH a gamechanger, thanks Bill! Because of that I was able to fix this example without dropping support for Zod v1.