### PR TITLE
fix: yup resolver TypeScript errors

### DIFF
--- a/src/yup.test.ts
+++ b/src/yup.test.ts
@@ -121,12 +121,7 @@ describe('yupResolver', () => {
         foo: [{ loose: null }],
       };
 
-      const output = await yupResolver(schema)(
-        // @ts-expect-error
-        data,
-        {},
-        true,
-      );
+      const output = await yupResolver(schema)(data, {}, true);
       expect(output).toMatchSnapshot();
       expect(output.errors['foo']?.[0]?.['loose']).toBeDefined();
       expect(output.errors['foo']?.[0]?.['loose']?.types)
@@ -168,7 +163,6 @@ describe('yupResolver', () => {
         foo: [{ loose: null }],
       };
 
-      // @ts-expect-error
       const output = await yupResolver(schema)(data);
       expect(output).toMatchSnapshot();
       expect(output.errors.age?.types).toBeUndefined();
@@ -185,7 +179,6 @@ describe('yupResolver', () => {
       };
       const output = await yupResolver(schema, {
         abortEarly: true,
-        // @ts-expect-error
       })(data, undefined, true);
 
       expect(output.errors).toMatchInlineSnapshot(`
@@ -208,7 +201,6 @@ describe('yupResolver', () => {
         inner: [{ path: '', message: 'error1', type: 'required' }],
       });
 
-      // @ts-expect-error
       const output = await yupResolver(schemaWithContext)(data);
       expect(output).toMatchSnapshot();
     });
@@ -245,7 +237,6 @@ describe('validateWithSchema', () => {
         }),
     });
 
-    // @ts-expect-error
     expect(await yupResolver(schemaWithContext)(data, { min: true }))
       .toMatchInlineSnapshot(`
       Object {

--- a/src/yup.ts
+++ b/src/yup.ts
@@ -1,10 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-ts-comment */
-import {
-  Resolver,
-  ResolverError,
-  ResolverSuccess,
-  transformToNestObject,
-} from 'react-hook-form';
+import { Resolver, transformToNestObject, FieldValues } from 'react-hook-form';
 import Yup from 'yup';
 
 /**
@@ -62,12 +57,12 @@ type ValidateOptions<T extends Yup.AnyObjectSchema> = Parameters<
   T['validate']
 >[1];
 
-export const yupResolver = <T extends Yup.AnyObjectSchema>(
-  schema: T,
-  options: ValidateOptions<T> = {
+export const yupResolver = <TFieldValues extends FieldValues>(
+  schema: Yup.AnyObjectSchema,
+  options: ValidateOptions<Yup.AnyObjectSchema> = {
     abortEarly: false,
   },
-): Resolver<Yup.InferType<T>> => async (
+): Resolver<TFieldValues> => async (
   values,
   context,
   validateAllFieldCriteria = false,
@@ -85,12 +80,12 @@ export const yupResolver = <T extends Yup.AnyObjectSchema>(
         context,
       }),
       errors: {},
-    } as ResolverSuccess<Yup.InferType<T>>;
+    };
   } catch (e) {
     const parsedErrors = parseErrorSchema(e, validateAllFieldCriteria);
     return {
       values: {},
       errors: transformToNestObject(parsedErrors),
-    } as ResolverError<Yup.InferType<T>>;
+    };
   }
 };


### PR DESCRIPTION
Related to https://github.com/react-hook-form/resolvers/issues/97

I just put the original types back for the yup resolver.
I plan to improve them in V2 for all resolvers