### PR TITLE
fix: expose array element validation errors in zod resolver

### DIFF
--- a/src/__snapshots__/zod.test.ts.snap
+++ b/src/__snapshots__/zod.test.ts.snap
@@ -133,6 +133,23 @@ Object {
         "invalid_type": "Expected number, received string",
       },
     },
+    "likedUsers": Object {
+      "0": Object {
+        "id": Object {
+          "message": "Expected number, received string",
+          "type": "invalid_type",
+          "types": Object {
+            "invalid_type": "Expected number, received string",
+          },
+        },
+      },
+      "message": "Invalid input",
+      "type": "invalid_union",
+      "types": Object {
+        "invalid_type": "Expected undefined, received array",
+        "invalid_union": "Invalid input",
+      },
+    },
     "password": Object {
       "message": "Should be at least 8 characters",
       "type": "too_small",

--- a/src/zod.test.ts
+++ b/src/zod.test.ts
@@ -10,6 +10,13 @@ const schema = z
     author: z.object({
       id: z.number(),
     }),
+    likedUsers: z
+      .array(
+        z.object({
+          id: z.number(),
+        }),
+      )
+      .optional(),
     count: z.number().positive().int(),
     date: z.date(),
     url: z.string().url(),
@@ -36,6 +43,7 @@ describe('zodResolver', () => {
       author: {
         id: 1,
       },
+      likedUsers: [{ id: 1 }],
       count: 4,
       date: new Date(),
       url: 'https://github.com/react-hook-form/resolvers',
@@ -73,6 +81,7 @@ describe('zodResolver', () => {
       author: {
         id: '1',
       },
+      likedUsers: [{ id: '1' }],
       count: -5,
       date: 'date',
       password: 'R',


### PR DESCRIPTION
### Issue
I noticed that the errors for array elements are not exposed in the Zod resolver. In the current version, the error looks like this instead (notice it doesn't expose the index of the validation error):
```
    "likedUsers": Object {
      "message": "Invalid input",
      "type": "invalid_union",
      "types": Object {
        "invalid_union": "Invalid input",
      },
    },
```

### Changes
- I updated the resolver to look at `unionErrors` when parsing errors from Zod to fix this error. Only `ZodInvalidUnionError` can have other errors as field values. So checking the existence of `unionErrors` should be good enough. But I am open to ideas here.

- I changed the original code's `reduce` to a queue to handle deeply nested union errors.