### PR TITLE
add `criteriaMode: all` support to class-validator resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,23 +275,18 @@ const App = () => {
   } = useForm<User>({ resolver });
 
   return (
-    <div style={{ display: 'grid', placeContent: 'center', height: '90vh' }}>
-      <form
-        onSubmit={handleSubmit((data) => console.log(data))}
-        style={{ display: 'flex', flexDirection: 'column', rowGap: 4 }}
-      >
-        <input type="text" {...register('username')} />
-        {errors.username && <span>{errors.username.message}</span>}
+    <form onSubmit={handleSubmit((data) => console.log(data))}>
+      <input type="text" {...register('username')} />
+      {errors.username && <span>{errors.username.message}</span>}
 
-        <input type="text" {...register('email')} />
-        {errors.email && <span>{errors.email.message}</span>}
+      <input type="text" {...register('email')} />
+      {errors.email && <span>{errors.email.message}</span>}
 
-        <input type="number" {...register('age', { valueAsNumber: true })} />
-        {errors.age && <span>{errors.age.message}</span>}
+      <input type="number" {...register('age', { valueAsNumber: true })} />
+      {errors.age && <span>{errors.age.message}</span>}
 
-        <input type="submit" value="Submit" />
-      </form>
-    </div>
+      <input type="submit" value="Submit" />
+    </form>
   );
 };
 

--- a/class-validator/package.json
+++ b/class-validator/package.json
@@ -12,6 +12,8 @@
   "license": "MIT",
   "peerDependencies": {
     "react-hook-form": ">=6.6.0",
-    "@hookform/resolvers": ">=2.0.0"
+    "@hookform/resolvers": ">=2.0.0",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.12.0"
   }
 }

--- a/class-validator/src/__tests__/__snapshots__/class-validator.ts.snap
+++ b/class-validator/src/__tests__/__snapshots__/class-validator.ts.snap
@@ -85,3 +85,123 @@ Object {
   "values": Object {},
 }
 `;
+
+exports[`classValidatorResolver should return all the errors from classValidatorResolver when validation fails with \`validateAllFieldCriteria\` set to true 1`] = `
+Object {
+  "errors": Object {
+    "birthYear": Object {
+      "message": "birthYear must not be greater than 2013",
+      "ref": undefined,
+      "type": "max",
+      "types": Object {
+        "max": "birthYear must not be greater than 2013",
+        "min": "birthYear must not be less than 1900",
+      },
+    },
+    "email": Object {
+      "message": "email must be an email",
+      "ref": Object {
+        "name": "email",
+      },
+      "type": "isEmail",
+      "types": Object {
+        "isEmail": "email must be an email",
+      },
+    },
+    "like": Array [
+      Object {
+        "name": Object {
+          "message": "name must be longer than or equal to 4 characters",
+          "ref": undefined,
+          "type": "isLength",
+          "types": Object {
+            "isLength": "name must be longer than or equal to 4 characters",
+          },
+        },
+      },
+    ],
+    "password": Object {
+      "message": "password must match /^[a-zA-Z0-9]{3,30}/ regular expression",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "matches",
+      "types": Object {
+        "matches": "password must match /^[a-zA-Z0-9]{3,30}/ regular expression",
+      },
+    },
+    "username": Object {
+      "message": "username must be longer than or equal to 3 characters",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "isLength",
+      "types": Object {
+        "isLength": "username must be longer than or equal to 3 characters",
+        "matches": "username must match /^\\\\w+$/ regular expression",
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`classValidatorResolver should return all the errors from classValidatorResolver when validation fails with \`validateAllFieldCriteria\` set to true and \`mode: sync\` 1`] = `
+Object {
+  "errors": Object {
+    "birthYear": Object {
+      "message": "birthYear must not be greater than 2013",
+      "ref": undefined,
+      "type": "max",
+      "types": Object {
+        "max": "birthYear must not be greater than 2013",
+        "min": "birthYear must not be less than 1900",
+      },
+    },
+    "email": Object {
+      "message": "email must be an email",
+      "ref": Object {
+        "name": "email",
+      },
+      "type": "isEmail",
+      "types": Object {
+        "isEmail": "email must be an email",
+      },
+    },
+    "like": Array [
+      Object {
+        "name": Object {
+          "message": "name must be longer than or equal to 4 characters",
+          "ref": undefined,
+          "type": "isLength",
+          "types": Object {
+            "isLength": "name must be longer than or equal to 4 characters",
+          },
+        },
+      },
+    ],
+    "password": Object {
+      "message": "password must match /^[a-zA-Z0-9]{3,30}/ regular expression",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "matches",
+      "types": Object {
+        "matches": "password must match /^[a-zA-Z0-9]{3,30}/ regular expression",
+      },
+    },
+    "username": Object {
+      "message": "username must be longer than or equal to 3 characters",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "isLength",
+      "types": Object {
+        "isLength": "username must be longer than or equal to 3 characters",
+        "matches": "username must match /^\\\\w+$/ regular expression",
+      },
+    },
+  },
+  "values": Object {},
+}
+`;

--- a/class-validator/src/__tests__/__snapshots__/class-validator.ts.snap
+++ b/class-validator/src/__tests__/__snapshots__/class-validator.ts.snap
@@ -6,32 +6,37 @@ Object {
     "birthYear": Object {
       "message": "birthYear must not be greater than 2013",
       "ref": undefined,
+      "type": "max",
     },
     "email": Object {
       "message": "email must be an email",
       "ref": Object {
         "name": "email",
       },
+      "type": "isEmail",
     },
-    "like": Object {
-      "0": Object {
+    "like": Array [
+      Object {
         "name": Object {
           "message": "name must be longer than or equal to 4 characters",
+          "ref": undefined,
+          "type": "isLength",
         },
       },
-      "ref": undefined,
-    },
+    ],
     "password": Object {
       "message": "password must match /^[a-zA-Z0-9]{3,30}/ regular expression",
       "ref": Object {
         "name": "password",
       },
+      "type": "matches",
     },
     "username": Object {
       "message": "username must be longer than or equal to 3 characters",
       "ref": Object {
         "name": "username",
       },
+      "type": "isLength",
     },
   },
   "values": Object {},
@@ -44,32 +49,37 @@ Object {
     "birthYear": Object {
       "message": "birthYear must not be greater than 2013",
       "ref": undefined,
+      "type": "max",
     },
     "email": Object {
       "message": "email must be an email",
       "ref": Object {
         "name": "email",
       },
+      "type": "isEmail",
     },
-    "like": Object {
-      "0": Object {
+    "like": Array [
+      Object {
         "name": Object {
           "message": "name must be longer than or equal to 4 characters",
+          "ref": undefined,
+          "type": "isLength",
         },
       },
-      "ref": undefined,
-    },
+    ],
     "password": Object {
       "message": "password must match /^[a-zA-Z0-9]{3,30}/ regular expression",
       "ref": Object {
         "name": "password",
       },
+      "type": "matches",
     },
     "username": Object {
       "message": "username must be longer than or equal to 3 characters",
       "ref": Object {
         "name": "username",
       },
+      "type": "isLength",
     },
   },
   "values": Object {},

--- a/class-validator/src/__tests__/class-validator.ts
+++ b/class-validator/src/__tests__/class-validator.ts
@@ -54,4 +54,28 @@ describe('classValidatorResolver', () => {
     expect(validateSpy).not.toHaveBeenCalled();
     expect(result).toMatchSnapshot();
   });
+
+  it('should return all the errors from classValidatorResolver when validation fails with `validateAllFieldCriteria` set to true', async () => {
+    const result = await classValidatorResolver(Schema)(
+      invalidData,
+      undefined,
+      {
+        fields,
+        criteriaMode: 'all',
+      },
+    );
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should return all the errors from classValidatorResolver when validation fails with `validateAllFieldCriteria` set to true and `mode: sync`', async () => {
+    const result = await classValidatorResolver(Schema, undefined, {
+      mode: 'sync',
+    })(invalidData, undefined, {
+      fields,
+      criteriaMode: 'all',
+    });
+
+    expect(result).toMatchSnapshot();
+  });
 });


### PR DESCRIPTION
- [Fix nested errors](https://github.com/react-hook-form/resolvers/commit/bcdf56bfea15a93301876c6af3a816d08d321298)
- [support `criteriaMode: all`](https://github.com/react-hook-form/resolvers/commit/a419de2aac2ceca9a92a4db5b47c0553ccac3464)
- [perf: reduce bundle size (~93% per bundle)](https://github.com/react-hook-form/resolvers/commit/c61fd8f845c2ba0024c2819ce9ecde11e668dbc6)
- Fix warning at build time: 
   >The 'this' keyword is equivalent to 'undefined' at the top level of an ES module, and has been rewritten