### PR TITLE
Remove redundant reflect metadata import

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Decorator-based property validation for classes.
 ```
 
 ```tsx
-import 'reflect-metadata';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { classValidatorResolver } from '@hookform/resolvers/class-validator';


### PR DESCRIPTION
`import reflect-metadata` is not needed in this example. I left it by mistake.

It is needed when you use `class-transformer`, e.g.
```tsx
import "reflect-metadata"; // Here! But it's preffered to import it only once in place like `src/index.tsx`
import { Length, ValidateNested } from "class-validator";
import { Type } from "class-transformer"; // So we must import reflect-metadata, like above ^

class Friend {
  @Length(3, 30)
  username: string;
}

export class User {
  @Length(3, 30)
  username: string;

  @ValidateNested()
  @Type(() => Friend)
  bestFriend: Friend;
}
```