### PR TITLE
Fix resolvers typings with `react-hook-form@7.15.0`

### DIFF
--- a/class-validator/src/__tests__/Form-native-validation.tsx
+++ b/class-validator/src/__tests__/Form-native-validation.tsx
@@ -14,7 +14,7 @@ class Schema {
 }
 
 interface Props {
-  onSubmit: (data: FormData) => void;
+  onSubmit: (data: Schema) => void;
 }
 
 function TestComponent({ onSubmit }: Props) {

--- a/class-validator/src/__tests__/Form.tsx
+++ b/class-validator/src/__tests__/Form.tsx
@@ -14,7 +14,7 @@ class Schema {
 }
 
 interface Props {
-  onSubmit: (data: FormData) => void;
+  onSubmit: (data: Schema) => void;
 }
 
 function TestComponent({ onSubmit }: Props) {

--- a/class-validator/src/types.ts
+++ b/class-validator/src/types.ts
@@ -7,11 +7,15 @@ import {
 import { ValidatorOptions } from 'class-validator';
 import { ClassConstructor } from 'class-transformer';
 
-export type Resolver = <T extends { [_: string]: any }>(
+export type Resolver = <
+  T extends { [_: string]: any },
+  TFieldValues extends FieldValues,
+  TContext,
+>(
   schema: ClassConstructor<T>,
   schemaOptions?: ValidatorOptions,
   resolverOptions?: { mode?: 'async' | 'sync' },
-) => <TFieldValues extends FieldValues, TContext>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/io-ts/src/__tests__/Form-native-validation.tsx
+++ b/io-ts/src/__tests__/Form-native-validation.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { useForm } from 'react-hook-form';
+import { SubmitHandler, useForm } from 'react-hook-form';
 import * as t from 'io-ts';
 import * as tt from 'io-ts-types';
 import { ioTsResolver } from '..';
@@ -10,21 +10,21 @@ const USERNAME_REQUIRED_MESSAGE = 'username field is required';
 const PASSWORD_REQUIRED_MESSAGE = 'password field is required';
 
 const schema = t.type({
-  username: tt.withMessage(t.string, () => USERNAME_REQUIRED_MESSAGE),
-  password: tt.withMessage(t.string, () => PASSWORD_REQUIRED_MESSAGE),
+  username: tt.withMessage(tt.NonEmptyString, () => USERNAME_REQUIRED_MESSAGE),
+  password: tt.withMessage(tt.NonEmptyString, () => PASSWORD_REQUIRED_MESSAGE),
 });
 
 interface FormData {
-  username: string;
-  password: string;
+  username: tt.NonEmptyString;
+  password: tt.NonEmptyString;
 }
 
 interface Props {
-  onSubmit: (data: FormData) => void;
+  onSubmit: SubmitHandler<FormData>;
 }
 
 function TestComponent({ onSubmit }: Props) {
-  const { register, handleSubmit } = useForm<FormData>({
+  const { register, handleSubmit } = useForm({
     resolver: ioTsResolver(schema),
     shouldUseNativeValidation: true,
   });

--- a/io-ts/src/__tests__/Form-native-validation.tsx
+++ b/io-ts/src/__tests__/Form-native-validation.tsx
@@ -10,8 +10,8 @@ const USERNAME_REQUIRED_MESSAGE = 'username field is required';
 const PASSWORD_REQUIRED_MESSAGE = 'password field is required';
 
 const schema = t.type({
-  username: tt.withMessage(tt.NonEmptyString, () => USERNAME_REQUIRED_MESSAGE),
-  password: tt.withMessage(tt.NonEmptyString, () => PASSWORD_REQUIRED_MESSAGE),
+  username: tt.withMessage(t.string, () => USERNAME_REQUIRED_MESSAGE),
+  password: tt.withMessage(t.string, () => PASSWORD_REQUIRED_MESSAGE),
 });
 
 interface FormData {

--- a/io-ts/src/__tests__/Form.tsx
+++ b/io-ts/src/__tests__/Form.tsx
@@ -7,14 +7,8 @@ import * as tt from 'io-ts-types';
 import { ioTsResolver } from '..';
 
 const schema = t.type({
-  username: tt.withMessage(
-    tt.NonEmptyString,
-    () => 'username is a required field',
-  ),
-  password: tt.withMessage(
-    tt.NonEmptyString,
-    () => 'password is a required field',
-  ),
+  username: tt.withMessage(t.string, () => 'username is a required field'),
+  password: tt.withMessage(t.string, () => 'password is a required field'),
 });
 
 interface FormData {

--- a/io-ts/src/__tests__/Form.tsx
+++ b/io-ts/src/__tests__/Form.tsx
@@ -1,23 +1,29 @@
 import React from 'react';
 import { render, screen, act } from '@testing-library/react';
 import user from '@testing-library/user-event';
-import { useForm } from 'react-hook-form';
+import { NestedValue, SubmitHandler, useForm } from 'react-hook-form';
 import * as t from 'io-ts';
 import * as tt from 'io-ts-types';
 import { ioTsResolver } from '..';
 
 const schema = t.type({
-  username: tt.withMessage(t.string, () => 'username is a required field'),
-  password: tt.withMessage(t.string, () => 'password is a required field'),
+  username: tt.withMessage(
+    tt.NonEmptyString,
+    () => 'username is a required field',
+  ),
+  password: tt.withMessage(
+    tt.NonEmptyString,
+    () => 'password is a required field',
+  ),
 });
 
 interface FormData {
-  username: string;
-  password: string;
+  username: NestedValue<tt.NonEmptyString>;
+  password: NestedValue<tt.NonEmptyString>;
 }
 
 interface Props {
-  onSubmit: (data: FormData) => void;
+  onSubmit: SubmitHandler<FormData>;
 }
 
 function TestComponent({ onSubmit }: Props) {
@@ -26,7 +32,7 @@ function TestComponent({ onSubmit }: Props) {
     formState: { errors },
     handleSubmit,
   } = useForm<FormData>({
-    resolver: ioTsResolver(schema),
+    resolver: ioTsResolver<FormData>(schema),
     criteriaMode: 'all',
   });
 

--- a/io-ts/src/io-ts.ts
+++ b/io-ts/src/io-ts.ts
@@ -3,6 +3,7 @@ import { pipe } from 'fp-ts/function';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import errorsToRecord from './errorsToRecord';
 import { Resolver } from './types';
+import { FieldErrors } from 'react-hook-form';
 
 export const ioTsResolver: Resolver = (codec) => (values, _context, options) =>
   pipe(
@@ -25,7 +26,7 @@ export const ioTsResolver: Resolver = (codec) => (values, _context, options) =>
 
         return {
           values,
-          errors: {},
+          errors: {} as FieldErrors<any>,
         };
       },
     ),

--- a/io-ts/src/types.ts
+++ b/io-ts/src/types.ts
@@ -1,14 +1,13 @@
 import * as t from 'io-ts';
 import {
   FieldError,
-  FieldValues,
   ResolverOptions,
   ResolverResult,
   UnpackNestedValue,
 } from 'react-hook-form';
 
-export type Resolver = <T, TFieldValues, TContext>(
-  codec: t.Decoder<FieldValues, T>,
+export type Resolver = <TFieldValues, TContext>(
+  codec: t.Decoder<unknown, any>,
 ) => (
   values: UnpackNestedValue<TFieldValues>,
   _context: TContext | undefined,

--- a/io-ts/src/types.ts
+++ b/io-ts/src/types.ts
@@ -1,13 +1,18 @@
 /* eslint-disable @typescript-eslint/ban-types */
 import * as t from 'io-ts';
-import { FieldError, ResolverOptions, ResolverResult } from 'react-hook-form';
+import {
+  FieldError,
+  ResolverOptions,
+  ResolverResult,
+  UnpackNestedValue,
+} from 'react-hook-form';
 
 export type Resolver = <
   TFieldValues,
   TInput extends unknown = unknown,
   TContext extends object = object,
 >(
-  codec: t.Decoder<TInput, TFieldValues>,
+  codec: t.Decoder<TInput, UnpackNestedValue<TFieldValues>>,
 ) => (
   values: TInput,
   _context: TContext | undefined,

--- a/io-ts/src/types.ts
+++ b/io-ts/src/types.ts
@@ -1,15 +1,15 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import * as t from 'io-ts';
-import {
-  FieldError,
-  ResolverOptions,
-  ResolverResult,
-  UnpackNestedValue,
-} from 'react-hook-form';
+import { FieldError, ResolverOptions, ResolverResult } from 'react-hook-form';
 
-export type Resolver = <TFieldValues, TContext>(
-  codec: t.Decoder<unknown, any>,
+export type Resolver = <
+  TFieldValues,
+  TInput extends unknown = unknown,
+  TContext extends object = object,
+>(
+  codec: t.Decoder<TInput, TFieldValues>,
 ) => (
-  values: UnpackNestedValue<TFieldValues>,
+  values: TInput,
   _context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,
 ) => ResolverResult<TFieldValues>;

--- a/joi/src/types.ts
+++ b/joi/src/types.ts
@@ -1,16 +1,15 @@
 import {
-  FieldValues,
   ResolverOptions,
   ResolverResult,
   UnpackNestedValue,
 } from 'react-hook-form';
 import type { AsyncValidationOptions, Schema } from 'joi';
 
-export type Resolver = <T extends Schema>(
+export type Resolver = <T extends Schema, TFieldValues, TContext>(
   schema: T,
   schemaOptions?: AsyncValidationOptions,
   factoryOptions?: { mode?: 'async' | 'sync' },
-) => <TFieldValues extends FieldValues, TContext>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/nope/src/types.ts
+++ b/nope/src/types.ts
@@ -1,5 +1,4 @@
 import type {
-  FieldValues,
   ResolverOptions,
   ResolverResult,
   UnpackNestedValue,
@@ -9,10 +8,14 @@ import type { NopeObject } from 'nope-validator/lib/cjs/NopeObject';
 type ValidateOptions = Parameters<NopeObject['validate']>[2];
 type Context = Parameters<NopeObject['validate']>[1];
 
-export type Resolver = <T extends NopeObject>(
+export type Resolver = <
+  T extends NopeObject,
+  TFieldValues,
+  TContext extends Context,
+>(
   schema: T,
   schemaOptions?: ValidateOptions,
-) => <TFieldValues extends FieldValues, TContext extends Context>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/package.json
+++ b/package.json
@@ -192,7 +192,7 @@
     "prettier": "^2.3.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-hook-form": "7.12.2",
+    "react-hook-form": "7.15.0",
     "reflect-metadata": "^0.1.13",
     "superstruct": "^0.15.2",
     "ts-jest": "^27.0.4",

--- a/src/toNestError.ts
+++ b/src/toNestError.ts
@@ -5,16 +5,17 @@ import {
   FieldErrors,
   Field,
   ResolverOptions,
+  FieldValues,
 } from 'react-hook-form';
 import { validateFieldsNatively } from './validateFieldsNatively';
 
-export const toNestError = <TFieldValues>(
+export const toNestError = <TFieldValues extends FieldValues>(
   errors: Record<string, FieldError>,
   options: ResolverOptions<TFieldValues>,
 ): FieldErrors<TFieldValues> => {
   options.shouldUseNativeValidation && validateFieldsNatively(errors, options);
 
-  const fieldErrors: FieldErrors<TFieldValues> = {};
+  const fieldErrors = {} as FieldErrors<TFieldValues>;
   for (const path in errors) {
     const field = get(options.fields, path) as Field['_f'] | undefined;
 

--- a/superstruct/src/__tests__/Form.tsx
+++ b/superstruct/src/__tests__/Form.tsx
@@ -21,7 +21,7 @@ function TestComponent({ onSubmit }: Props) {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<FormData>({
+  } = useForm({
     resolver: superstructResolver(schema), // Useful to check TypeScript regressions
   });
 

--- a/superstruct/src/superstruct.ts
+++ b/superstruct/src/superstruct.ts
@@ -1,4 +1,4 @@
-import { FieldError } from 'react-hook-form';
+import { FieldError, FieldErrors } from 'react-hook-form';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 
 import { StructError, validate } from 'superstruct';
@@ -21,7 +21,10 @@ export const superstructResolver: Resolver =
     if (result[0]) {
       return {
         values: {},
-        errors: toNestError(parseErrorSchema(result[0]), options),
+        errors: toNestError(
+          parseErrorSchema(result[0]),
+          options,
+        ) as FieldErrors<any>,
       };
     }
 
@@ -29,6 +32,6 @@ export const superstructResolver: Resolver =
 
     return {
       values: result[1],
-      errors: {},
+      errors: {} as FieldErrors<any>,
     };
   };

--- a/superstruct/src/types.ts
+++ b/superstruct/src/types.ts
@@ -1,17 +1,13 @@
-import {
-  ResolverOptions,
-  ResolverResult,
-  UnpackNestedValue,
-} from 'react-hook-form';
+import { FieldValues, ResolverOptions, ResolverResult } from 'react-hook-form';
 import { validate, Struct } from 'superstruct';
 
 type Options = Parameters<typeof validate>[2];
 
-export type Resolver = <T extends Struct<any, any>, TFieldValues, TContext>(
-  schema: T,
+export type Resolver = <TFieldValues extends FieldValues, TContext>(
+  schema: Struct<TFieldValues, any>,
   factoryOptions?: Options,
 ) => (
-  values: UnpackNestedValue<TFieldValues>,
+  values: unknown,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,
 ) => ResolverResult<TFieldValues>;

--- a/superstruct/src/types.ts
+++ b/superstruct/src/types.ts
@@ -9,7 +9,7 @@ type Options = Parameters<typeof validate>[2];
 
 export type Resolver = <T extends Struct<any, any>, TFieldValues, TContext>(
   schema: T,
-  factoryOtions?: Options,
+  factoryOptions?: Options,
 ) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/superstruct/src/types.ts
+++ b/superstruct/src/types.ts
@@ -1,9 +1,13 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import { FieldValues, ResolverOptions, ResolverResult } from 'react-hook-form';
 import { validate, Struct } from 'superstruct';
 
 type Options = Parameters<typeof validate>[2];
 
-export type Resolver = <TFieldValues extends FieldValues, TContext>(
+export type Resolver = <
+  TFieldValues extends FieldValues,
+  TContext extends object = object,
+>(
   schema: Struct<TFieldValues, any>,
   factoryOptions?: Options,
 ) => (

--- a/superstruct/src/types.ts
+++ b/superstruct/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  FieldValues,
   ResolverOptions,
   ResolverResult,
   UnpackNestedValue,
@@ -8,10 +7,10 @@ import { validate, Struct } from 'superstruct';
 
 type Options = Parameters<typeof validate>[2];
 
-export type Resolver = <T extends Struct<any, any>>(
+export type Resolver = <T extends Struct<any, any>, TFieldValues, TContext>(
   schema: T,
   factoryOtions?: Options,
-) => <TFieldValues extends FieldValues, TContext>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/typanion/src/__tests__/Form-native-validation.tsx
+++ b/typanion/src/__tests__/Form-native-validation.tsx
@@ -5,7 +5,8 @@ import { useForm } from 'react-hook-form';
 import * as t from 'typanion';
 import { typanionResolver } from '..';
 
-const ERROR_MESSAGE = 'Expected to have a length of at least 1 elements (got 0)';
+const ERROR_MESSAGE =
+  'Expected to have a length of at least 1 elements (got 0)';
 
 const schema = t.isObject({
   username: t.applyCascade(t.isString(), [t.hasMinLength(1)]),
@@ -23,7 +24,7 @@ interface Props {
 }
 
 function TestComponent({ onSubmit }: Props) {
-  const { register, handleSubmit } = useForm<FormData>({
+  const { register, handleSubmit } = useForm({
     resolver: typanionResolver(schema),
     shouldUseNativeValidation: true,
   });

--- a/typanion/src/__tests__/Form.tsx
+++ b/typanion/src/__tests__/Form.tsx
@@ -25,7 +25,7 @@ function TestComponent({ onSubmit }: Props) {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<FormData>({
+  } = useForm({
     resolver: typanionResolver(schema), // Useful to check TypeScript regressions
   });
 
@@ -52,6 +52,10 @@ test("form's validation with Typanion and TypeScript's integration", async () =>
     user.click(screen.getByText(/submit/i));
   });
 
-  expect(screen.getAllByText('Expected to have a length of at least 1 elements (got 0)')).toHaveLength(2);
+  expect(
+    screen.getAllByText(
+      'Expected to have a length of at least 1 elements (got 0)',
+    ),
+  ).toHaveLength(2);
   expect(handleSubmit).not.toHaveBeenCalled();
 });

--- a/typanion/src/typanion.ts
+++ b/typanion/src/typanion.ts
@@ -34,8 +34,11 @@ export const typanionResolver: Resolver =
       options.shouldUseNativeValidation &&
         validateFieldsNatively(parsedErrors, options);
 
-      return { values, errors: {} };
+      return { values, errors: {} as FieldErrors<any> };
     }
 
-    return { values: {}, errors: toNestError(parsedErrors, options) };
+    return {
+      values: {},
+      errors: toNestError(parsedErrors, options) as FieldErrors<any>,
+    };
   };

--- a/typanion/src/types.ts
+++ b/typanion/src/types.ts
@@ -1,20 +1,28 @@
+/* eslint-disable @typescript-eslint/ban-types */
 import type {
   FieldValues,
   ResolverOptions,
   ResolverResult,
-  UnpackNestedValue,
 } from 'react-hook-form';
-import { ValidationState, AnyStrictValidator} from 'typanion'
+import { ValidationState, StrictValidator } from 'typanion';
 
-type ValidateOptions = Pick<ValidationState, 'coercions' | 'coercion'>
+type ValidateOptions = Pick<ValidationState, 'coercions' | 'coercion'>;
 
-type RHFResolver = <TFieldValues extends FieldValues, TContext>(
-  values: UnpackNestedValue<TFieldValues>,
+type RHFResolver<
+  TFieldValues extends FieldValues,
+  TInput = unknown,
+  TContext extends Object = object,
+> = (
+  values: TInput,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,
 ) => ResolverResult<TFieldValues>;
 
-export type Resolver = <UnknownValidator extends AnyStrictValidator>(
-  validator: UnknownValidator,
+export type Resolver = <
+  TInput extends FieldValues = FieldValues,
+  TFieldValues extends TInput = TInput,
+  TContext extends object = object,
+>(
+  validator: StrictValidator<TInput, TFieldValues>,
   validatorOptions?: ValidateOptions,
-)=> RHFResolver
+) => RHFResolver<TFieldValues, TInput, TContext>;

--- a/vest/src/types.ts
+++ b/vest/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  FieldValues,
   ResolverOptions,
   ResolverResult,
   UnpackNestedValue,
@@ -8,11 +7,11 @@ import * as Vest from 'vest';
 
 export type ICreateResult = ReturnType<typeof Vest.create>;
 
-export type Resolver = (
+export type Resolver = <TFieldValues, TContext>(
   schema: ICreateResult,
   schemaOptions?: never,
   factoryOptions?: { mode?: 'async' | 'sync' },
-) => <TFieldValues extends FieldValues, TContext>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,14 +1739,6 @@
     "@typescript-eslint/typescript-estree" "4.29.2"
     debug "^4.3.1"
 
-"@typescript-eslint/scope-manager@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.1.tgz#f25da25bc6512812efa2ce5ebd36619d68e61358"
-  integrity sha512-Hzv/uZOa9zrD/W5mftZa54Jd5Fed3tL6b4HeaOpwVSabJK8CJ+2MkDasnX/XK4rqP5ZTWngK1ZDeCi6EnxPQ7A==
-  dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/visitor-keys" "4.29.1"
-
 "@typescript-eslint/scope-manager@4.29.2":
   version "4.29.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-4.29.2.tgz#442b0f029d981fa402942715b1718ac7fcd5aa1b"
@@ -1755,28 +1747,10 @@
     "@typescript-eslint/types" "4.29.2"
     "@typescript-eslint/visitor-keys" "4.29.2"
 
-"@typescript-eslint/types@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.1.tgz#94cce6cf7cc83451df03339cda99d326be2feaf5"
-  integrity sha512-Jj2yu78IRfw4nlaLtKjVaGaxh/6FhofmQ/j8v3NXmAiKafbIqtAPnKYrf0sbGjKdj0hS316J8WhnGnErbJ4RCA==
-
 "@typescript-eslint/types@4.29.2":
   version "4.29.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.29.2.tgz#fc0489c6b89773f99109fb0aa0aaddff21f52fcd"
   integrity sha512-K6ApnEXId+WTGxqnda8z4LhNMa/pZmbTFkDxEBLQAbhLZL50DjeY0VIDCml/0Y3FlcbqXZrABqrcKxq+n0LwzQ==
-
-"@typescript-eslint/typescript-estree@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-4.29.1.tgz#7b32a25ff8e51f2671ccc6b26cdbee3b1e6c5e7f"
-  integrity sha512-lIkkrR9E4lwZkzPiRDNq0xdC3f2iVCUjw/7WPJ4S2Sl6C3nRWkeE1YXCQ0+KsiaQRbpY16jNaokdWnm9aUIsfw==
-  dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    "@typescript-eslint/visitor-keys" "4.29.1"
-    debug "^4.3.1"
-    globby "^11.0.3"
-    is-glob "^4.0.1"
-    semver "^7.3.5"
-    tsutils "^3.21.0"
 
 "@typescript-eslint/typescript-estree@4.29.2":
   version "4.29.2"
@@ -1790,14 +1764,6 @@
     is-glob "^4.0.1"
     semver "^7.3.5"
     tsutils "^3.21.0"
-
-"@typescript-eslint/visitor-keys@4.29.1":
-  version "4.29.1"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-4.29.1.tgz#0615be8b55721f5e854f3ee99f1a714f2d093e5d"
-  integrity sha512-zLqtjMoXvgdZY/PG6gqA73V8BjqPs4af1v2kiiETBObp+uC6gRYnJLmJHxC0QyUrrHDLJPIWNYxoBV3wbcRlag==
-  dependencies:
-    "@typescript-eslint/types" "4.29.1"
-    eslint-visitor-keys "^2.0.0"
 
 "@typescript-eslint/visitor-keys@4.29.2":
   version "4.29.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5446,10 +5446,10 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-hook-form@7.12.2:
-  version "7.12.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.12.2.tgz#2660afbf03c4ef360a9314ebf46ce3d972296c77"
-  integrity sha512-cpxocjrgpMAJCMJQR51BQhMoEx80/EQqePNihMTgoTYTqCRbd2GExi+N4GJIr+cFqrmbwNj9wxk5oLWYQsUefg==
+react-hook-form@7.15.0:
+  version "7.15.0"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.15.0.tgz#f6eb3a18ca797d39a5407114db07719d5c55e7fb"
+  integrity sha512-UWEkNhcTvA+o/FUZ2RMvpKgxxEg0rJqEjHMDwh3I4TIdHX38TtN8IywyGieqeWLiHEpoNVOuEhLVPZ9/srXUhA==
 
 react-is@^17.0.1:
   version "17.0.2"

--- a/yup/src/__tests__/Form-native-validation.tsx
+++ b/yup/src/__tests__/Form-native-validation.tsx
@@ -20,7 +20,7 @@ interface Props {
 }
 
 function TestComponent({ onSubmit }: Props) {
-  const { register, handleSubmit } = useForm<FormData>({
+  const { register, handleSubmit } = useForm({
     resolver: yupResolver(schema),
     shouldUseNativeValidation: true,
   });

--- a/yup/src/__tests__/Form.tsx
+++ b/yup/src/__tests__/Form.tsx
@@ -21,7 +21,7 @@ function TestComponent({ onSubmit }: Props) {
     register,
     formState: { errors },
     handleSubmit,
-  } = useForm<FormData>({
+  } = useForm({
     resolver: yupResolver(schema), // Useful to check TypeScript regressions
   });
 

--- a/yup/src/types.ts
+++ b/yup/src/types.ts
@@ -1,8 +1,5 @@
-import {
-  ResolverOptions,
-  ResolverResult,
-  UnpackNestedValue,
-} from 'react-hook-form';
+/* eslint-disable @typescript-eslint/ban-types */
+import { ResolverOptions, ResolverResult } from 'react-hook-form';
 import * as Yup from 'yup';
 import type Lazy from 'yup/lib/Lazy';
 
@@ -10,12 +7,15 @@ type Options<T extends Yup.AnyObjectSchema | Lazy<any>> = Parameters<
   T['validate']
 >[1];
 
-export type Resolver = <T extends Yup.AnyObjectSchema | Lazy<any>, TFieldValues, TContext>(
+export type Resolver = <
+  T extends Yup.AnyObjectSchema | Lazy<any>,
+  TContext extends object = object,
+>(
   schema: T,
   schemaOptions?: Options<T>,
   factoryOptions?: { mode?: 'async' | 'sync' },
 ) => (
-  values: UnpackNestedValue<TFieldValues>,
+  values: unknown,
   context: TContext | undefined,
-  options: ResolverOptions<TFieldValues>,
-) => Promise<ResolverResult<TFieldValues>>;
+  options: ResolverOptions<Yup.InferType<T>>,
+) => Promise<ResolverResult<Yup.InferType<T>>>;

--- a/yup/src/types.ts
+++ b/yup/src/types.ts
@@ -11,11 +11,11 @@ type Options<T extends Yup.AnyObjectSchema | Lazy<any>> = Parameters<
   T['validate']
 >[1];
 
-export type Resolver = <T extends Yup.AnyObjectSchema | Lazy<any>>(
+export type Resolver = <T extends Yup.AnyObjectSchema | Lazy<any>, TFieldValues, TContext>(
   schema: T,
   schemaOptions?: Options<T>,
   factoryOptions?: { mode?: 'async' | 'sync' },
-) => <TFieldValues extends FieldValues, TContext>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/yup/src/types.ts
+++ b/yup/src/types.ts
@@ -1,5 +1,4 @@
 import {
-  FieldValues,
   ResolverOptions,
   ResolverResult,
   UnpackNestedValue,

--- a/yup/src/yup.ts
+++ b/yup/src/yup.ts
@@ -1,4 +1,4 @@
-import Yup from 'yup';
+import Yup, { ValidationError } from 'yup';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import { appendErrors, FieldError } from 'react-hook-form';
 import { Resolver } from './types';
@@ -64,7 +64,7 @@ export const yupResolver: Resolver =
         values: {},
         errors: toNestError(
           parseErrorSchema(
-            e,
+            e as ValidationError,
             !options.shouldUseNativeValidation &&
               options.criteriaMode === 'all',
           ),

--- a/zod/src/__tests__/Form.tsx
+++ b/zod/src/__tests__/Form.tsx
@@ -21,7 +21,7 @@ function TestComponent({ onSubmit }: Props) {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<FormData>({
+  } = useForm({
     resolver: zodResolver(schema), // Useful to check TypeScript regressions
   });
 

--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -1,17 +1,16 @@
-import {
-  ResolverResult,
-  UnpackNestedValue,
-  ResolverOptions,
-  FieldValues,
-} from 'react-hook-form';
+/* eslint-disable @typescript-eslint/ban-types */
+import { ResolverResult, ResolverOptions, FieldValues } from 'react-hook-form';
 import { z } from 'zod';
 
-export type Resolver = <TFieldValues extends FieldValues, TContext>(
-  schema: z.Schema<any, any>,
+export type Resolver = <
+  TFieldValues extends FieldValues,
+  TContext extends object = object,
+>(
+  schema: z.Schema<TFieldValues, any>,
   schemaOptions?: Partial<z.ParseParamsNoData>,
   factoryOptions?: { mode?: 'async' | 'sync' },
 ) => (
-  values: UnpackNestedValue<TFieldValues>,
+  values: unknown,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,
 ) => Promise<ResolverResult<TFieldValues>>;

--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -2,11 +2,12 @@ import {
   ResolverResult,
   UnpackNestedValue,
   ResolverOptions,
+  FieldValues,
 } from 'react-hook-form';
 import { z } from 'zod';
 
-export type Resolver = <T extends z.Schema<any, any>, TFieldValues, TContext>(
-  schema: T,
+export type Resolver = <TFieldValues extends FieldValues, TContext>(
+  schema: z.Schema<any, any>,
   schemaOptions?: Partial<z.ParseParamsNoData>,
   factoryOptions?: { mode?: 'async' | 'sync' },
 ) => (

--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -1,16 +1,15 @@
 import {
-  FieldValues,
   ResolverResult,
   UnpackNestedValue,
   ResolverOptions,
 } from 'react-hook-form';
 import { z } from 'zod';
 
-export type Resolver = <T extends z.Schema<any, any>>(
+export type Resolver = <T extends z.Schema<any, any>, TFieldValues, TContext>(
   schema: T,
   schemaOptions?: Partial<z.ParseParamsNoData>,
   factoryOptions?: { mode?: 'async' | 'sync' },
-) => <TFieldValues extends FieldValues, TContext>(
+) => (
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,
   options: ResolverOptions<TFieldValues>,

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -1,4 +1,4 @@
-import { appendErrors, FieldError } from 'react-hook-form';
+import { appendErrors, FieldError, FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import type { Resolver } from './types';
@@ -64,22 +64,22 @@ export const zodResolver: Resolver =
       options.shouldUseNativeValidation && validateFieldsNatively({}, options);
 
       return {
-        errors: {},
+        errors: {} as FieldErrors<any>,
         values: data,
       };
     } catch (error) {
       return {
         values: {},
         errors: error.isEmpty
-          ? {}
-          : toNestError(
+          ? ({} as FieldErrors<any>)
+          : (toNestError(
               parseErrorSchema(
                 error.errors,
                 !options.shouldUseNativeValidation &&
                   options.criteriaMode === 'all',
               ),
               options,
-            ),
+            ) as FieldErrors<any>),
       };
     }
   };

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -1,5 +1,5 @@
 import { appendErrors, FieldError, FieldErrors } from 'react-hook-form';
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import type { Resolver } from './types';
 
@@ -70,11 +70,11 @@ export const zodResolver: Resolver =
     } catch (error) {
       return {
         values: {},
-        errors: error.isEmpty
+        errors: (error as ZodError).isEmpty
           ? ({} as FieldErrors<any>)
           : (toNestError(
               parseErrorSchema(
-                error.errors,
+                (error as ZodError).errors,
                 !options.shouldUseNativeValidation &&
                   options.criteriaMode === 'all',
               ),


### PR DESCRIPTION
I upgraded to the latest `react-hook-form` and `@hookform/resolvers` versions and all of a sudden all my forms that were using the `yupResolver` were throwing a typescript error while those using the io-ts resolver (I'm progressively migrating to io-ts) didn't.

I checked what could be the source and figured the typings were not infered properly when wrapping the generic function.

Example of something that does not work:

```typescript
const { register } = useForm<Type>({
  resolver: yupResolver(schema),
});
```

Fixes #234