### PR TITLE
zod.nonempty() is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 
 const schema = z.object({
-  name: z.string().nonempty({ message: 'Required' }),
+  name: z.string().min(1, { message: 'Required' }),
   age: z.number().min(10),
 });
 


### PR DESCRIPTION
`.nonempty()` is deprecated adn replaced by `.min(1)` as per zod documentation.
See https://github.com/colinhacks/zod#strings