### PR TITLE
Add ability to skip zod's parsing

### DIFF
--- a/zod/src/__tests__/__fixtures__/data.ts
+++ b/zod/src/__tests__/__fixtures__/data.ts
@@ -29,13 +29,19 @@ export const schema = z
         }),
       )
       .optional(),
+    dateStr: z
+      .string()
+      .transform((value) => new Date(value))
+      .refine((value) => !isNaN(value.getTime()), {
+        message: 'Invalid date',
+      }),
   })
   .refine((obj) => obj.password === obj.repeatPassword, {
     message: 'Passwords do not match',
     path: ['confirm'],
   });
 
-export const validData: z.infer<typeof schema> = {
+export const validData: z.input<typeof schema> = {
   username: 'Doe',
   password: 'Password123_',
   repeatPassword: 'Password123_',
@@ -51,6 +57,7 @@ export const validData: z.infer<typeof schema> = {
       name: 'name',
     },
   ],
+  dateStr: '2020-01-01',
 };
 
 export const invalidData = {

--- a/zod/src/__tests__/__snapshots__/zod.ts.snap
+++ b/zod/src/__tests__/__snapshots__/zod.ts.snap
@@ -13,6 +13,11 @@ Object {
       "ref": undefined,
       "type": "invalid_type",
     },
+    "dateStr": Object {
+      "message": "Required",
+      "ref": undefined,
+      "type": "invalid_type",
+    },
     "email": Object {
       "message": "Invalid email",
       "ref": Object {
@@ -83,6 +88,11 @@ Object {
     },
     "birthYear": Object {
       "message": "Expected number, received string",
+      "ref": undefined,
+      "type": "invalid_type",
+    },
+    "dateStr": Object {
+      "message": "Required",
       "ref": undefined,
       "type": "invalid_type",
     },
@@ -167,6 +177,14 @@ Object {
       "type": "invalid_type",
       "types": Object {
         "invalid_type": "Expected number, received string",
+      },
+    },
+    "dateStr": Object {
+      "message": "Required",
+      "ref": undefined,
+      "type": "invalid_type",
+      "types": Object {
+        "invalid_type": "Required",
       },
     },
     "email": Object {
@@ -284,6 +302,14 @@ Object {
         "invalid_type": "Expected number, received string",
       },
     },
+    "dateStr": Object {
+      "message": "Required",
+      "ref": undefined,
+      "type": "invalid_type",
+      "types": Object {
+        "invalid_type": "Required",
+      },
+    },
     "email": Object {
       "message": "Invalid email",
       "ref": Object {
@@ -373,5 +399,32 @@ Object {
     },
   },
   "values": Object {},
+}
+`;
+
+exports[`zodResolver should return parsed values from zodResolver with \`mode: sync\` when validation pass 1`] = `
+Object {
+  "errors": Object {},
+  "values": Object {
+    "accessToken": "accessToken",
+    "birthYear": 2000,
+    "dateStr": 2020-01-01T00:00:00.000Z,
+    "email": "john@doe.com",
+    "enabled": true,
+    "like": Array [
+      Object {
+        "id": 1,
+        "name": "name",
+      },
+    ],
+    "password": "Password123_",
+    "repeatPassword": "Password123_",
+    "tags": Array [
+      "tag1",
+      "tag2",
+    ],
+    "url": "https://react-hook-form.com/",
+    "username": "Doe",
+  },
 }
 `;

--- a/zod/src/__tests__/zod.ts
+++ b/zod/src/__tests__/zod.ts
@@ -4,10 +4,12 @@ import { schema, validData, invalidData, fields } from './__fixtures__/data';
 const shouldUseNativeValidation = false;
 
 describe('zodResolver', () => {
-  it('should return values from zodResolver when validation pass', async () => {
+  it('should return values from zodResolver when validation pass & rawValues=true', async () => {
     const parseAsyncSpy = jest.spyOn(schema, 'parseAsync');
 
-    const result = await zodResolver(schema)(validData, undefined, {
+    const result = await zodResolver(schema, undefined, {
+      rawValues: true,
+    })(validData, undefined, {
       fields,
       shouldUseNativeValidation,
     });
@@ -16,7 +18,7 @@ describe('zodResolver', () => {
     expect(result).toEqual({ errors: {}, values: validData });
   });
 
-  it('should return values from zodResolver with `mode: sync` when validation pass', async () => {
+  it('should return parsed values from zodResolver with `mode: sync` when validation pass', async () => {
     const parseSpy = jest.spyOn(schema, 'parse');
     const parseAsyncSpy = jest.spyOn(schema, 'parseAsync');
 
@@ -26,7 +28,8 @@ describe('zodResolver', () => {
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(parseAsyncSpy).not.toHaveBeenCalled();
-    expect(result).toEqual({ errors: {}, values: validData });
+    expect(result.errors).toEqual({});
+    expect(result).toMatchSnapshot();
   });
 
   it('should return a single error from zodResolver when validation fails', async () => {

--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -6,22 +6,20 @@ import {
 } from 'react-hook-form';
 import { z } from 'zod';
 
-interface FactoryOptions {
-  /**
-   * @default async
-   */
-  mode?: 'async' | 'sync';
-  /**
-   * Return the raw input values rather than the parsed values.
-   * @default false
-   */
-  rawValues?: boolean;
-}
-
 export type Resolver = <T extends z.Schema<any, any>>(
   schema: T,
   schemaOptions?: Partial<z.ParseParams>,
-  factoryOptions?: FactoryOptions,
+  factoryOptions?: {
+    /**
+     * @default async
+     */
+    mode?: 'async' | 'sync';
+    /**
+     * Return the raw input values rather than the parsed values.
+     * @default false
+     */
+    rawValues?: boolean;
+  },
 ) => <TFieldValues extends FieldValues, TContext>(
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -6,10 +6,22 @@ import {
 } from 'react-hook-form';
 import { z } from 'zod';
 
+interface FactoryOptions {
+  /**
+   * @default async
+   */
+  mode?: 'async' | 'sync';
+  /**
+   * Return the raw input values rather than the parsed values.
+   * @default false
+   */
+  rawValues?: boolean;
+}
+
 export type Resolver = <T extends z.Schema<any, any>>(
   schema: T,
   schemaOptions?: Partial<z.ParseParams>,
-  factoryOptions?: { mode?: 'async' | 'sync' },
+  factoryOptions?: FactoryOptions,
 ) => <TFieldValues extends FieldValues, TContext>(
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -69,7 +69,7 @@ export const zodResolver: Resolver =
 
         return {
           errors: {} as FieldErrors,
-          values: data,
+          values: resolverOptions.rawValues ? values : data,
         };
       } catch (error: any) {
         return {


### PR DESCRIPTION
When using [tRPC](https://trpc.io/), it's common to use the same validation schema on the server as the client. Therefore, it's good to be able to send the unparsed raw values from the client to the server.

Maybe this should be the default behavior, unsure if it's intentional to be as it is.