### PR TITLE
feat: update for resolvers with new `rawValues` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,14 @@
 
 ## API
 
-`resolver(schema: object, schemaOptions?: object, resolverOptions: { mode: 'async' | 'sync' })`
+```
+type Options = { 
+  mode: 'async' | 'sync',
+  rawValues?: boolean 
+}
+
+resolver(schema: object, schemaOptions?: object, resolverOptions: Options)
+````
 
 |                 | type     | Required | Description                                   |
 | --------------- | -------- | -------- | --------------------------------------------- |

--- a/class-validator/src/types.ts
+++ b/class-validator/src/types.ts
@@ -10,7 +10,7 @@ import { ClassConstructor } from 'class-transformer';
 export type Resolver = <T extends { [_: string]: any }>(
   schema: ClassConstructor<T>,
   schemaOptions?: ValidatorOptions,
-  resolverOptions?: { mode?: 'async' | 'sync' },
+  resolverOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
 ) => <TFieldValues extends FieldValues, TContext>(
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/nope/src/types.ts
+++ b/nope/src/types.ts
@@ -12,6 +12,7 @@ type Context = Parameters<NopeObject['validate']>[1];
 export type Resolver = <T extends NopeObject>(
   schema: T,
   schemaOptions?: ValidateOptions,
+  resolverOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
 ) => <TFieldValues extends FieldValues, TContext extends Context>(
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/typanion/src/types.ts
+++ b/typanion/src/types.ts
@@ -17,4 +17,5 @@ type RHFResolver = <TFieldValues extends FieldValues, TContext>(
 export type Resolver = <UnknownValidator extends AnyStrictValidator>(
   validator: UnknownValidator,
   validatorOptions?: ValidateOptions,
+  resolverOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
 )=> RHFResolver

--- a/vest/src/types.ts
+++ b/vest/src/types.ts
@@ -11,7 +11,7 @@ export type ICreateResult = ReturnType<typeof Vest.create>;
 export type Resolver = (
   schema: ICreateResult,
   schemaOptions?: never,
-  factoryOptions?: { mode?: 'async' | 'sync' },
+  factoryOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
 ) => <TFieldValues extends FieldValues, TContext>(
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/yup/src/types.ts
+++ b/yup/src/types.ts
@@ -14,7 +14,7 @@ type Options<T extends Yup.AnyObjectSchema | Lazy<any>> = Parameters<
 export type Resolver = <T extends Yup.AnyObjectSchema | Lazy<any>>(
   schema: T,
   schemaOptions?: Options<T>,
-  factoryOptions?: { mode?: 'async' | 'sync' },
+  factoryOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
 ) => <TFieldValues extends FieldValues, TContext>(
   values: UnpackNestedValue<TFieldValues>,
   context: TContext | undefined,

--- a/yup/src/yup.ts
+++ b/yup/src/yup.ts
@@ -59,7 +59,7 @@ export const yupResolver: Resolver =
       options.shouldUseNativeValidation && validateFieldsNatively({}, options);
 
       return {
-        values: result,
+        values: resolverOptions.rawValues ? values : result,
         errors: {},
       };
     } catch (e: any) {


### PR DESCRIPTION
update types for all resolvers

```tsx
type Options = { 
  mode: 'async' | 'sync',
  rawValues?: boolean 
}
resolver(schema: object, schemaOptions?: object, resolverOptions: Options)
````
