### PR TITLE
chore(exports): improve nested conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,76 +10,136 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "browser": "./dist/resolvers.module.js",
+      "browser": {
+        "import": "./dist/resolvers.module.js",
+        "require": "./dist/resolvers.js"
+      },
       "umd": "./dist/resolvers.umd.js",
-      "import": "./dist/resolvers.mjs",
-      "require": "./dist/resolvers.js"
+      "node": {
+        "import": "./dist/resolvers.mjs",
+        "require": "./dist/resolvers.js"
+      }
     },
     "./zod": {
-      "browser": "./zod/dist/zod.module.js",
+      "browser": {
+        "import": "./zod/dist/zod.module.js",
+        "require": "./zod/dist/zod.js"
+      },
       "umd": "./zod/dist/zod.umd.js",
-      "import": "./zod/dist/zod.mjs",
-      "require": "./zod/dist/zod.js"
+      "node": {
+        "import": "./zod/dist/zod.mjs",
+        "require": "./zod/dist/zod.js"
+      }
     },
     "./yup": {
-      "browser": "./yup/dist/yup.module.js",
+      "browser": {
+        "import": "./yup/dist/yup.module.js",
+        "require": "./yup/dist/yup.js"
+      },
       "umd": "./yup/dist/yup.umd.js",
-      "import": "./yup/dist/yup.mjs",
-      "require": "./yup/dist/yup.js"
+      "node": {
+        "import": "./yup/dist/yup.mjs",
+        "require": "./yup/dist/yup.js"
+      }
     },
     "./joi": {
-      "browser": "./joi/dist/joi.module.js",
+      "browser": {
+        "import": "./joi/dist/joi.module.js",
+        "require": "./joi/dist/joi.js"
+      },
       "umd": "./joi/dist/joi.umd.js",
-      "import": "./joi/dist/joi.mjs",
-      "require": "./joi/dist/joi.js"
+      "node": {
+        "import": "./joi/dist/joi.mjs",
+        "require": "./joi/dist/joi.js"
+      }
     },
     "./vest": {
-      "browser": "./vest/dist/vest.module.js",
+      "browser": {
+        "import": "./vest/dist/vest.module.js",
+        "require": "./vest/dist/vest.js"
+      },
       "umd": "./vest/dist/vest.umd.js",
-      "import": "./vest/dist/vest.mjs",
-      "require": "./vest/dist/vest.js"
+      "node": {
+        "import": "./vest/dist/vest.mjs",
+        "require": "./vest/dist/vest.js"
+      }
     },
     "./superstruct": {
-      "browser": "./superstruct/dist/superstruct.module.js",
+      "browser": {
+        "import": "./superstruct/dist/superstruct.module.js",
+        "require": "./superstruct/dist/superstruct.js"
+      },
       "umd": "./superstruct/dist/superstruct.umd.js",
-      "import": "./superstruct/dist/superstruct.mjs",
-      "require": "./superstruct/dist/superstruct.js"
+      "node": {
+        "import": "./superstruct/dist/superstruct.mjs",
+        "require": "./superstruct/dist/superstruct.js"
+      }
     },
     "./class-validator": {
-      "browser": "./class-validator/dist/class-validator.module.js",
+      "browser": {
+        "import": "./class-validator/dist/class-validator.module.js",
+        "require": "./class-validator/dist/class-validator.js"
+      },
       "umd": "./class-validator/dist/class-validator.umd.js",
-      "import": "./class-validator/dist/class-validator.mjs",
-      "require": "./class-validator/dist/class-validator.js"
+      "node": {
+        "import": "./class-validator/dist/class-validator.mjs",
+        "require": "./class-validator/dist/class-validator.js"
+      }
     },
     "./io-ts": {
-      "browser": "./io-ts/dist/io-ts.module.js",
+      "browser": {
+        "import": "./io-ts/dist/io-ts.module.js",
+        "require": "./io-ts/dist/io-ts.js"
+      },
       "umd": "./io-ts/dist/io-ts.umd.js",
-      "import": "./io-ts/dist/io-ts.mjs",
-      "require": "./io-ts/dist/io-ts.js"
+      "node": {
+        "import": "./io-ts/dist/io-ts.mjs",
+        "require": "./io-ts/dist/io-ts.js"
+      }
     },
     "./nope": {
-      "browser": "./nope/dist/nope.module.js",
+      "browser": {
+        "import": "./nope/dist/nope.module.js",
+        "require": "./nope/dist/nope.js"
+      },
       "umd": "./nope/dist/nope.umd.js",
-      "import": "./nope/dist/nope.mjs",
-      "require": "./nope/dist/nope.js"
+      "node": {
+        "import": "./nope/dist/nope.mjs",
+        "require": "./nope/dist/nope.js"
+      }
     },
     "./computed-types": {
-      "browser": "./computed-types/dist/computed-types.module.js",
+      "browser": {
+        "import": "./computed-types/dist/computed-types.module.js",
+        "require": "./computed-types/dist/computed-types.js"
+      },
       "umd": "./computed-types/dist/computed-types.umd.js",
-      "import": "./computed-types/dist/computed-types.mjs",
-      "require": "./computed-types/dist/computed-types.js"
+      "node": {
+        "import": "./computed-types/dist/computed-types.mjs",
+        "require": "./computed-types/dist/computed-types.js"
+      }
     },
     "./typanion": {
-      "browser": "./typanion/dist/typanion.module.js",
+      "browser": {
+        "import": "./typanion/dist/typanion.module.js",
+        "require": "./typanion/dist/typanion.js"
+      },
       "umd": "./typanion/dist/typanion.umd.js",
-      "import": "./typanion/dist/typanion.mjs",
-      "require": "./typanion/dist/typanion.js"
+      "node": {
+        "import": "./typanion/dist/typanion.mjs",
+        "require": "./typanion/dist/typanion.js"
+      }
     },
     "./ajv": {
-      "browser": "./ajv/dist/ajv.module.js",
+      "browser": {
+        "import": "./ajv/dist/ajv.module.js",
+        "require": "./ajv/dist/ajv.js"
+      },
       "umd": "./ajv/dist/ajv.umd.js",
-      "import": "./ajv/dist/ajv.mjs",
-      "require": "./ajv/dist/ajv.js"
+      "node": {
+        "import": "./ajv/dist/ajv.mjs",
+        "require": "./ajv/dist/ajv.js"
+      }
     },
     "./package.json": "./package.json",
     "./*": "./*"


### PR DESCRIPTION
This proposal follow [this issue](https://github.com/react-hook-form/resolvers/issues/396).

After digging a little bit in the linked issues, I found [this](https://github.com/xnimorz/use-debounce/issues/132) issue where [this particular comment](https://github.com/xnimorz/use-debounce/issues/132#issuecomment-1119090837) give an hint on how to solve this module resolution issue.

If I well understood reading the [Jest 28 doc](https://jestjs.io/docs/upgrading-to-jest28#packagejson-exports) we need to provide both `require` and `import` exports for browser too.

[Further reading on the `"exports"` spec](https://nodejs.org/api/packages.html#nested-conditions)

NB: This change in local raise the issue in [this issue](https://github.com/react-hook-form/resolvers/issues/396).

close #396