### PR TITLE
fix: ajv resolver to work with unlimited layers of nesting

### DIFF
--- a/ajv/src/__tests__/__fixtures__/data.ts
+++ b/ajv/src/__tests__/__fixtures__/data.ts
@@ -4,7 +4,7 @@ import { Field, InternalFieldName } from 'react-hook-form';
 interface Data {
   username: string;
   password: string;
-  deepObject: { data: string };
+  deepObject: { data: string; twoLayersDeep: { name: string } };
 }
 
 export const schema: JSONSchemaType<Data> = {
@@ -26,8 +26,14 @@ export const schema: JSONSchemaType<Data> = {
       nullable: true,
       properties: {
         data: { type: 'string' },
+        twoLayersDeep: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: false,
+          required: ['name'],
+        },
       },
-      required: ['data'],
+      required: ['data', 'twoLayersDeep'],
     },
   },
   required: ['username', 'password', 'deepObject'],
@@ -38,6 +44,9 @@ export const validData: Data = {
   username: 'jsun969',
   password: 'validPassword',
   deepObject: {
+    twoLayersDeep: {
+      name: 'deeper',
+    },
     data: 'data',
   },
 };
@@ -47,6 +56,7 @@ export const invalidData = {
   password: 'invalid-password',
   deepObject: {
     data: 233,
+    twoLayersDeep: { name: 123 }
   },
 };
 

--- a/ajv/src/__tests__/__snapshots__/ajv.ts.snap
+++ b/ajv/src/__tests__/__snapshots__/ajv.ts.snap
@@ -66,6 +66,16 @@ Object {
           "type": "must be string",
         },
       },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+          "types": Object {
+            "type": "must be string",
+          },
+        },
+      },
     },
     "password": Object {
       "message": "One uppercase character",
@@ -104,6 +114,16 @@ Object {
           "type": "must be string",
         },
       },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+          "types": Object {
+            "type": "must be string",
+          },
+        },
+      },
     },
     "password": Object {
       "message": "One uppercase character",
@@ -139,6 +159,13 @@ Object {
         "ref": undefined,
         "type": "type",
       },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+        },
+      },
     },
     "password": Object {
       "message": "One uppercase character",
@@ -167,6 +194,13 @@ Object {
         "message": "must be string",
         "ref": undefined,
         "type": "type",
+      },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+        },
       },
     },
     "password": Object {

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -17,7 +17,7 @@ const parseErrorSchema = (
 
   return ajvErrors.reduce<Record<string, FieldError>>((previous, error) => {
     // `/deepObject/data` -> `deepObject.data`
-    const path = error.instancePath.substring(1).replace('/', '.');
+    const path = error.instancePath.substring(1).replace(/\//g, '.');
 
     if (!previous[path]) {
       previous[path] = {


### PR DESCRIPTION
The current implementation of `ajv` resolver didn't support well more than 2 layers of nesting. The error keys wouldn't match the shape of the data. See below `data/category`.

The below schema results in:

```js
{
  type: 'object', 
  properties: {
    row: {
      type: 'object',
      properties: {
	name: {
	  type: 'string',
	  minLength: 10,
	  errorMessage: { minLength: 'Username should be at least 10 characters' },
	},
	data: {
	  type: 'object',
	  properties: {
	    category: {
	      type: 'string',
	      minLength: 1,
	      errorMessage: { minLength: 'Category is required' },
	    }
	  },
	  required: ['category'],
	  additionalProperties: true,
	}
      },
      required: ['name', 'data'],
      additionalProperties: true,
    },
  },
  required: ['row'],
  additionalProperties: false,
};

```

<img width="999" alt="Screen Shot 2022-06-10 at 1 18 20 pm" src="https://user-images.githubusercontent.com/4208193/172983627-f6ba7ae0-49b8-4bb1-924c-cb57c89a0b6f.png">
 
The fix is to essentially replace all occurrences of `/` instead of only the first one.