### PR TITLE
Infer form type from zod schema

### DIFF
--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -1,9 +1,4 @@
-import {
-  FieldValues,
-  ResolverResult,
-  UnpackNestedValue,
-  ResolverOptions,
-} from 'react-hook-form';
+import { Resolver as HookFormResolver } from 'react-hook-form';
 import { z } from 'zod';
 
 export type Resolver = <T extends z.Schema<any, any>>(
@@ -20,8 +15,4 @@ export type Resolver = <T extends z.Schema<any, any>>(
      */
     rawValues?: boolean;
   },
-) => <TFieldValues extends FieldValues, TContext>(
-  values: UnpackNestedValue<TFieldValues>,
-  context: TContext | undefined,
-  options: ResolverOptions<TFieldValues>,
-) => Promise<ResolverResult<TFieldValues>>;
+) => HookFormResolver<z.infer<T>>;


### PR DESCRIPTION
Hi all,

I'm not sure if there's a specific reason this wasn't happening, but the react-hook-forms resolver type can overwrite the generic for TFieldValues. When you do this it allows typescript to infer the types in the form (for example in the submit handler), to match what the zod schema is producing.

I've included the change below :+1: 

Thanks,
Maddi