### PR TITLE
Prefer `fp-ts/Either` over `fp-ts/lib/Either`

### DIFF
--- a/io-ts/src/io-ts.ts
+++ b/io-ts/src/io-ts.ts
@@ -1,4 +1,4 @@
-import * as Either from 'fp-ts/lib/Either';
+import * as Either from 'fp-ts/Either';
 import { pipe } from 'fp-ts/function';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import errorsToRecord from './errorsToRecord';


### PR DESCRIPTION
Unlike other import statements, this one points not to `fp-ts/Either` but to `fp-ts/lib/Either`, which is a CommonJS file (`node_modules/fp-ts/lib/Either.js`).
This causes an error when you import `@hookform/resolvers/io-ts` from a ES module, where a file extension is mandatory in import sources, as `fp-ts/lib/Either` lacks `.js` extension.
Importing from `fp-ts/Either` (just as all other imports do so) solves the problem, since the `package.json` switches CJS/ESM.