### PR TITLE
Renamed private packages to avoid ambiguity with existing official packages. This should mitigate false positives during image scans.

### DIFF
--- a/ajv/package.json
+++ b/ajv/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "ajv",
+  "name": "@hookform/resolvers/ajv",
   "amdName": "hookformResolversAjv",
   "version": "1.0.0",
   "private": true,

--- a/class-validator/package.json
+++ b/class-validator/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "class-validator",
+  "name": "@hookform/resolvers/class-validator",
   "amdName": "hookformResolversClassValidator",
   "version": "1.0.0",
   "private": true,

--- a/computed-types/package.json
+++ b/computed-types/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "computed-types",
+  "name": "@hookform/resolvers/computed-types",
   "amdName": "hookformResolversComputedTypes",
   "version": "1.0.0",
   "private": true,

--- a/io-ts/package.json
+++ b/io-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "io-ts",
+  "name": "@hookform/resolvers/io-ts",
   "amdName": "hookformResolversIoTs",
   "version": "1.0.0",
   "private": true,

--- a/joi/package.json
+++ b/joi/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "joi",
+  "name": "@hookform/resolvers/joi",
   "amdName": "hookformResolversJoi",
   "version": "1.0.0",
   "private": true,

--- a/nope/package.json
+++ b/nope/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "nope",
+  "name": "@hookform/resolvers/nope",
   "amdName": "hookformResolversNope",
   "version": "1.0.0",
   "private": true,

--- a/superstruct/package.json
+++ b/superstruct/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "superstruct",
+  "name": "@hookform/resolvers/superstruct",
   "amdName": "hookformResolversSuperstruct",
   "version": "1.0.0",
   "private": true,

--- a/typanion/package.json
+++ b/typanion/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "typanion",
+  "name": "@hookform/resolvers/typanion",
   "amdName": "hookformResolversTypanion",
   "version": "1.0.0",
   "private": true,

--- a/vest/package.json
+++ b/vest/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vest",
+  "name": "@hookform/resolvers/vest",
   "amdName": "hookformResolversVest",
   "version": "1.0.0",
   "private": true,

--- a/yup/package.json
+++ b/yup/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "yup",
+  "name": "@hookform/resolvers/yup",
   "amdName": "hookformResolversYup",
   "version": "1.0.0",
   "private": true,

--- a/zod/package.json
+++ b/zod/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "zod",
+  "name": "@hookform/resolvers/zod",
   "amdName": "hookformResolversZod",
   "version": "1.0.0",
   "private": true,


### PR DESCRIPTION
This PR addresses the issue raised here: https://github.com/react-hook-form/resolvers/issues/423

This change was pretty minor but I did have a couple of questions:
- Would you prefer if I changed the path for these dependencies as well? I decided against it because it might be a breaking change but I can update the PR with that if you'd like.
- I get a warning about the new package names due to the double forward slashes (/) failing the regex. It doesn't have an impact since these are private packages but I wasn't sure if you would rather I use a different naming convention. Something like "@hookform/resolvers.ajv" perhaps.
![image](https://user-images.githubusercontent.com/29155351/176792402-3a9e703b-f17b-43f2-a445-bfec7c68bfb7.png)

