### PR TITLE
[AJV] Add option to run ajv with ajv-formats

### DIFF
--- a/ajv/src/__tests__/__fixtures__/data.ts
+++ b/ajv/src/__tests__/__fixtures__/data.ts
@@ -7,6 +7,10 @@ interface Data {
   deepObject: { data: string; twoLayersDeep: { name: string } };
 }
 
+interface Email {
+  email: string;
+}
+
 export const schema: JSONSchemaType<Data> = {
   type: 'object',
   properties: {
@@ -56,7 +60,7 @@ export const invalidData = {
   password: 'invalid-password',
   deepObject: {
     data: 233,
-    twoLayersDeep: { name: 123 }
+    twoLayersDeep: { name: 123 },
   },
 };
 
@@ -77,4 +81,27 @@ export const fields: Record<InternalFieldName, Field['_f']> = {
     ref: { name: 'birthday' },
     name: 'birthday',
   },
+};
+
+export const schemaFormat: JSONSchemaType<Email> = {
+  type: 'object',
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email',
+      errorMessage: {
+        format: 'email format is not valid',
+      },
+    },
+  },
+  required: ['email'],
+  additionalProperties: false,
+};
+
+export const validEmail: Email = {
+  email: 'asdf@asdf.as',
+};
+
+export const invalidEmail: Email = {
+  email: `invalid email`,
 };

--- a/ajv/src/__tests__/__snapshots__/ajv.ts.snap
+++ b/ajv/src/__tests__/__snapshots__/ajv.ts.snap
@@ -150,6 +150,21 @@ Object {
 }
 `;
 
+exports[`ajvResolver should return error messages from ajvResolver when format validation fails 1`] = `
+Object {
+  "errors": Object {
+    "email": Object {
+      "message": "email format is not valid",
+      "ref": Object {
+        "name": "email",
+      },
+      "type": "errorMessage",
+    },
+  },
+  "values": Object {},
+}
+`;
+
 exports[`ajvResolver should return single error message from ajvResolver when validation fails and validateAllFieldCriteria set to false 1`] = `
 Object {
   "errors": Object {

--- a/ajv/src/__tests__/ajv.ts
+++ b/ajv/src/__tests__/ajv.ts
@@ -1,5 +1,13 @@
 import { ajvResolver } from '..';
-import { fields, invalidData, schema, validData } from './__fixtures__/data';
+import {
+  fields,
+  invalidData,
+  invalidEmail,
+  schema,
+  schemaFormat,
+  validData,
+  validEmail,
+} from './__fixtures__/data';
 
 const shouldUseNativeValidation = false;
 
@@ -79,6 +87,35 @@ describe('ajvResolver', () => {
         fields,
         shouldUseNativeValidation,
       }),
+    ).toMatchSnapshot();
+  });
+
+  it('should return values from ajvResolver when format validation pass', async () => {
+    expect(
+      await ajvResolver(schemaFormat, undefined, { addFormats: true })(
+        validEmail,
+        undefined,
+        {
+          fields,
+          shouldUseNativeValidation,
+        },
+      ),
+    ).toEqual({
+      values: validEmail,
+      errors: {},
+    });
+  });
+
+  it('should return error messages from ajvResolver when format validation fails', async () => {
+    expect(
+      await ajvResolver(schemaFormat, undefined, { addFormats: true })(
+        invalidEmail,
+        undefined,
+        {
+          fields,
+          shouldUseNativeValidation,
+        },
+      ),
     ).toMatchSnapshot();
   });
 });

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -1,5 +1,6 @@
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import Ajv, { DefinedError } from 'ajv';
+import ajvFormats from 'ajv-formats';
 import ajvErrors from 'ajv-errors';
 import { appendErrors, FieldError } from 'react-hook-form';
 import { Resolver } from './types';
@@ -55,6 +56,9 @@ export const ajvResolver: Resolver =
     });
 
     ajvErrors(ajv);
+    if (resolverOptions?.addFormats) {
+      ajvFormats(ajv);
+    }
 
     const validate = ajv.compile(
       Object.assign({ $async: resolverOptions?.mode === 'async' }, schema),

--- a/ajv/src/types.ts
+++ b/ajv/src/types.ts
@@ -1,14 +1,10 @@
-import {
-  FieldValues,
-  ResolverOptions,
-  ResolverResult,
-} from 'react-hook-form';
+import { FieldValues, ResolverOptions, ResolverResult } from 'react-hook-form';
 import * as Ajv from 'ajv';
 
 export type Resolver = <T>(
   schema: Ajv.JSONSchemaType<T>,
   schemaOptions?: Ajv.Options,
-  factoryOptions?: { mode?: 'async' | 'sync' },
+  factoryOptions?: { mode?: 'async' | 'sync'; addFormats?: boolean },
 ) => <TFieldValues extends FieldValues, TContext>(
   values: TFieldValues,
   context: TContext | undefined,

--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "@typescript-eslint/eslint-plugin": "^5.10.0",
     "@typescript-eslint/parser": "^5.10.0",
     "ajv": "^8.11.0",
+    "ajv-formats": "^2.1.1",
     "ajv-errors": "^3.0.0",
     "check-export-map": "^1.2.0",
     "class-transformer": "^0.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,13 @@ ajv-errors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
   integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2029,20 +2036,20 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.6.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
-  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
+ajv@^8.0.0, ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+ajv@^8.0.1:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
Add option to extend the ajv resolver with [ajv-formats](https://ajv.js.org/packages/ajv-formats.html)

[ajv-formats](https://github.com/ajv-validator/ajv-formats) makes it easy and secure to validate *emails*, *urls*, *uuids*, and many others string formats.