### PR TITLE
feat: add a custom resolver ajv-formats

### DIFF
--- a/ajv-formats/package.json
+++ b/ajv-formats/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@hookform/resolvers/ajv-formats",
+  "amdName": "hookformResolversAjvFormats",
+  "version": "1.0.0",
+  "private": true,
+  "description": "React Hook Form validation resolver: ajv with ajv-formats",
+  "main": "dist/ajv-formats.js",
+  "module": "dist/ajv-formats.module.js",
+  "umd:main": "dist/ajv-formats.umd.js",
+  "source": "src/index.ts",
+  "types": "dist/index.d.ts",
+  "license": "MIT",
+  "peerDependencies": {
+    "react-hook-form": "^7.0.0",
+    "@hookform/resolvers": "^2.0.0"
+  }
+}

--- a/ajv-formats/src/__tests__/Form-native-validation.tsx
+++ b/ajv-formats/src/__tests__/Form-native-validation.tsx
@@ -1,0 +1,98 @@
+import { act, render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { JSONSchemaType } from 'ajv';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { ajvFormatsResolver } from '..';
+
+const USERNAME_REQUIRED_MESSAGE = 'username field is required';
+const PASSWORD_REQUIRED_MESSAGE = 'password field is required';
+
+type FormData = { username: string; password: string };
+
+const schema: JSONSchemaType<FormData> = {
+  type: 'object',
+  properties: {
+    username: {
+      type: 'string',
+      minLength: 1,
+      errorMessage: { minLength: USERNAME_REQUIRED_MESSAGE },
+    },
+    password: {
+      type: 'string',
+      minLength: 1,
+      errorMessage: { minLength: PASSWORD_REQUIRED_MESSAGE },
+    },
+  },
+  required: ['username', 'password'],
+  additionalProperties: false,
+};
+
+interface Props {
+  onSubmit: (data: FormData) => void;
+}
+
+function TestComponent({ onSubmit }: Props) {
+  const { register, handleSubmit } = useForm<FormData>({
+    resolver: ajvFormatsResolver(schema),
+    shouldUseNativeValidation: true,
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('username')} placeholder="username" />
+
+      <input {...register('password')} placeholder="password" />
+
+      <button type="submit">submit</button>
+    </form>
+  );
+}
+
+test("form's native validation with Ajv", async () => {
+  const handleSubmit = jest.fn();
+  render(<TestComponent onSubmit={handleSubmit} />);
+
+  // username
+  let usernameField = screen.getByPlaceholderText(
+    /username/i,
+  ) as HTMLInputElement;
+  expect(usernameField.validity.valid).toBe(true);
+  expect(usernameField.validationMessage).toBe('');
+
+  // password
+  let passwordField = screen.getByPlaceholderText(
+    /password/i,
+  ) as HTMLInputElement;
+  expect(passwordField.validity.valid).toBe(true);
+  expect(passwordField.validationMessage).toBe('');
+
+  await act(async () => {
+    user.click(screen.getByText(/submit/i));
+  });
+
+  // username
+  usernameField = screen.getByPlaceholderText(/username/i) as HTMLInputElement;
+  expect(usernameField.validity.valid).toBe(false);
+  expect(usernameField.validationMessage).toBe(USERNAME_REQUIRED_MESSAGE);
+
+  // password
+  passwordField = screen.getByPlaceholderText(/password/i) as HTMLInputElement;
+  expect(passwordField.validity.valid).toBe(false);
+  expect(passwordField.validationMessage).toBe(PASSWORD_REQUIRED_MESSAGE);
+
+  await act(async () => {
+    user.type(screen.getByPlaceholderText(/username/i), 'joe');
+    user.type(screen.getByPlaceholderText(/password/i), 'password');
+  });
+
+  // username
+  usernameField = screen.getByPlaceholderText(/username/i) as HTMLInputElement;
+  expect(usernameField.validity.valid).toBe(true);
+  expect(usernameField.validationMessage).toBe('');
+
+  // password
+  passwordField = screen.getByPlaceholderText(/password/i) as HTMLInputElement;
+  expect(passwordField.validity.valid).toBe(true);
+  expect(passwordField.validationMessage).toBe('');
+});

--- a/ajv-formats/src/__tests__/Form.tsx
+++ b/ajv-formats/src/__tests__/Form.tsx
@@ -1,0 +1,67 @@
+import { act, render, screen } from '@testing-library/react';
+import user from '@testing-library/user-event';
+import { JSONSchemaType } from 'ajv';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+import { ajvFormatsResolver } from '..';
+
+type FormData = { username: string; password: string };
+
+const schema: JSONSchemaType<FormData> = {
+  type: 'object',
+  properties: {
+    username: {
+      type: 'string',
+      minLength: 1,
+      errorMessage: { minLength: 'username field is required' },
+    },
+    password: {
+      type: 'string',
+      minLength: 1,
+      errorMessage: { minLength: 'password field is required' },
+    },
+  },
+  required: ['username', 'password'],
+  additionalProperties: false,
+};
+
+interface Props {
+  onSubmit: (data: FormData) => void;
+}
+
+function TestComponent({ onSubmit }: Props) {
+  const {
+    register,
+    formState: { errors },
+    handleSubmit,
+  } = useForm<FormData>({
+    resolver: ajvFormatsResolver(schema), // Useful to check TypeScript regressions
+  });
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <input {...register('username')} />
+      {errors.username && <span role="alert">{errors.username.message}</span>}
+
+      <input {...register('password')} />
+      {errors.password && <span role="alert">{errors.password.message}</span>}
+
+      <button type="submit">submit</button>
+    </form>
+  );
+}
+
+test("form's validation with Ajv and TypeScript's integration", async () => {
+  const handleSubmit = jest.fn();
+  render(<TestComponent onSubmit={handleSubmit} />);
+
+  expect(screen.queryAllByRole(/alert/i)).toHaveLength(0);
+
+  await act(async () => {
+    user.click(screen.getByText(/submit/i));
+  });
+
+  expect(screen.getByText(/username field is required/i)).toBeInTheDocument();
+  expect(screen.getByText(/password field is required/i)).toBeInTheDocument();
+  expect(handleSubmit).not.toHaveBeenCalled();
+});

--- a/ajv-formats/src/__tests__/__fixtures__/data.ts
+++ b/ajv-formats/src/__tests__/__fixtures__/data.ts
@@ -1,0 +1,107 @@
+import { JSONSchemaType } from 'ajv';
+import { Field, InternalFieldName } from 'react-hook-form';
+
+interface Data {
+  username: string;
+  password: string;
+  deepObject: { data: string; twoLayersDeep: { name: string } };
+}
+
+interface Email {
+  email: string;
+}
+
+export const schema: JSONSchemaType<Data> = {
+  type: 'object',
+  properties: {
+    username: {
+      type: 'string',
+      minLength: 3,
+    },
+    password: {
+      type: 'string',
+      pattern: '.*[A-Z].*',
+      errorMessage: {
+        pattern: 'One uppercase character',
+      },
+    },
+    deepObject: {
+      type: 'object',
+      nullable: true,
+      properties: {
+        data: { type: 'string' },
+        twoLayersDeep: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: false,
+          required: ['name'],
+        },
+      },
+      required: ['data', 'twoLayersDeep'],
+    },
+  },
+  required: ['username', 'password', 'deepObject'],
+  additionalProperties: false,
+};
+
+export const validData: Data = {
+  username: 'jsun969',
+  password: 'validPassword',
+  deepObject: {
+    twoLayersDeep: {
+      name: 'deeper',
+    },
+    data: 'data',
+  },
+};
+
+export const invalidData = {
+  username: '__',
+  password: 'invalid-password',
+  deepObject: {
+    data: 233,
+    twoLayersDeep: { name: 123 },
+  },
+};
+
+export const fields: Record<InternalFieldName, Field['_f']> = {
+  username: {
+    ref: { name: 'username' },
+    name: 'username',
+  },
+  password: {
+    ref: { name: 'password' },
+    name: 'password',
+  },
+  email: {
+    ref: { name: 'email' },
+    name: 'email',
+  },
+  birthday: {
+    ref: { name: 'birthday' },
+    name: 'birthday',
+  },
+};
+
+export const schemaFormat: JSONSchemaType<Email> = {
+  type: 'object',
+  properties: {
+    email: {
+      type: 'string',
+      format: 'email',
+      errorMessage: {
+        format: 'email format is not valid',
+      },
+    },
+  },
+  required: ['email'],
+  additionalProperties: false,
+};
+
+export const validEmail: Email = {
+  email: 'asdf@asdf.as',
+};
+
+export const invalidEmail: Email = {
+  email: `invalid email`,
+};

--- a/ajv-formats/src/__tests__/__snapshots__/ajv-formats.ts.snap
+++ b/ajv-formats/src/__tests__/__snapshots__/ajv-formats.ts.snap
@@ -1,0 +1,238 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ajvFormatsResolver should return all the error messages from ajvFormatsResolver when requirement fails and validateAllFieldCriteria set to true 1`] = `
+Object {
+  "errors": Object {
+    "deepObject": Object {
+      "message": "must have required property 'deepObject'",
+      "ref": undefined,
+      "type": "required",
+    },
+    "password": Object {
+      "message": "must have required property 'password'",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "required",
+    },
+    "username": Object {
+      "message": "must have required property 'username'",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "required",
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvFormatsResolver should return all the error messages from ajvFormatsResolver when requirement fails and validateAllFieldCriteria set to true and \`mode: sync\` 1`] = `
+Object {
+  "errors": Object {
+    "deepObject": Object {
+      "message": "must have required property 'deepObject'",
+      "ref": undefined,
+      "type": "required",
+    },
+    "password": Object {
+      "message": "must have required property 'password'",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "required",
+    },
+    "username": Object {
+      "message": "must have required property 'username'",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "required",
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvFormatsResolver should return all the error messages from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to true 1`] = `
+Object {
+  "errors": Object {
+    "deepObject": Object {
+      "data": Object {
+        "message": "must be string",
+        "ref": undefined,
+        "type": "type",
+        "types": Object {
+          "type": "must be string",
+        },
+      },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+          "types": Object {
+            "type": "must be string",
+          },
+        },
+      },
+    },
+    "password": Object {
+      "message": "One uppercase character",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "errorMessage",
+      "types": Object {
+        "errorMessage": "One uppercase character",
+      },
+    },
+    "username": Object {
+      "message": "must NOT have fewer than 3 characters",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "minLength",
+      "types": Object {
+        "minLength": "must NOT have fewer than 3 characters",
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvFormatsResolver should return all the error messages from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to true and \`mode: sync\` 1`] = `
+Object {
+  "errors": Object {
+    "deepObject": Object {
+      "data": Object {
+        "message": "must be string",
+        "ref": undefined,
+        "type": "type",
+        "types": Object {
+          "type": "must be string",
+        },
+      },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+          "types": Object {
+            "type": "must be string",
+          },
+        },
+      },
+    },
+    "password": Object {
+      "message": "One uppercase character",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "errorMessage",
+      "types": Object {
+        "errorMessage": "One uppercase character",
+      },
+    },
+    "username": Object {
+      "message": "must NOT have fewer than 3 characters",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "minLength",
+      "types": Object {
+        "minLength": "must NOT have fewer than 3 characters",
+      },
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvFormatsResolver should return error messages from ajvFormatsResolver when format validation fails 1`] = `
+Object {
+  "errors": Object {
+    "email": Object {
+      "message": "email format is not valid",
+      "ref": Object {
+        "name": "email",
+      },
+      "type": "errorMessage",
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvFormatsResolver should return single error message from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to false 1`] = `
+Object {
+  "errors": Object {
+    "deepObject": Object {
+      "data": Object {
+        "message": "must be string",
+        "ref": undefined,
+        "type": "type",
+      },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+        },
+      },
+    },
+    "password": Object {
+      "message": "One uppercase character",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "errorMessage",
+    },
+    "username": Object {
+      "message": "must NOT have fewer than 3 characters",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "minLength",
+    },
+  },
+  "values": Object {},
+}
+`;
+
+exports[`ajvFormatsResolver should return single error message from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to false and \`mode: sync\` 1`] = `
+Object {
+  "errors": Object {
+    "deepObject": Object {
+      "data": Object {
+        "message": "must be string",
+        "ref": undefined,
+        "type": "type",
+      },
+      "twoLayersDeep": Object {
+        "name": Object {
+          "message": "must be string",
+          "ref": undefined,
+          "type": "type",
+        },
+      },
+    },
+    "password": Object {
+      "message": "One uppercase character",
+      "ref": Object {
+        "name": "password",
+      },
+      "type": "errorMessage",
+    },
+    "username": Object {
+      "message": "must NOT have fewer than 3 characters",
+      "ref": Object {
+        "name": "username",
+      },
+      "type": "minLength",
+    },
+  },
+  "values": Object {},
+}
+`;

--- a/ajv-formats/src/__tests__/ajv-formats.ts
+++ b/ajv-formats/src/__tests__/ajv-formats.ts
@@ -1,0 +1,117 @@
+import { ajvFormatsResolver } from '..';
+import {
+  fields,
+  invalidData,
+  invalidEmail,
+  schema,
+  schemaFormat,
+  validData,
+  validEmail,
+} from './__fixtures__/data';
+
+const shouldUseNativeValidation = false;
+
+describe('ajvFormatsResolver', () => {
+  it('should return values from ajvFormatsResolver when validation pass', async () => {
+    expect(
+      await ajvFormatsResolver(schema)(validData, undefined, {
+        fields,
+        shouldUseNativeValidation,
+      }),
+    ).toEqual({
+      values: validData,
+      errors: {},
+    });
+  });
+
+  it('should return values from ajvFormatsResolver with `mode: sync` when validation pass', async () => {
+    expect(
+      await ajvFormatsResolver(schema, undefined, {
+        mode: 'sync',
+      })(validData, undefined, { fields, shouldUseNativeValidation }),
+    ).toEqual({
+      values: validData,
+      errors: {},
+    });
+  });
+
+  it('should return single error message from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to false', async () => {
+    expect(
+      await ajvFormatsResolver(schema)(invalidData, undefined, {
+        fields,
+        shouldUseNativeValidation,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('should return single error message from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to false and `mode: sync`', async () => {
+    expect(
+      await ajvFormatsResolver(schema, undefined, {
+        mode: 'sync',
+      })(invalidData, undefined, { fields, shouldUseNativeValidation }),
+    ).toMatchSnapshot();
+  });
+
+  it('should return all the error messages from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to true', async () => {
+    expect(
+      await ajvFormatsResolver(schema)(
+        invalidData,
+        {},
+        { fields, criteriaMode: 'all', shouldUseNativeValidation },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('should return all the error messages from ajvFormatsResolver when validation fails and validateAllFieldCriteria set to true and `mode: sync`', async () => {
+    expect(
+      await ajvFormatsResolver(schema, undefined, { mode: 'sync' })(
+        invalidData,
+        {},
+        { fields, criteriaMode: 'all', shouldUseNativeValidation },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('should return all the error messages from ajvFormatsResolver when requirement fails and validateAllFieldCriteria set to true', async () => {
+    expect(
+      await ajvFormatsResolver(schema)({}, undefined, {
+        fields,
+        shouldUseNativeValidation,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('should return all the error messages from ajvFormatsResolver when requirement fails and validateAllFieldCriteria set to true and `mode: sync`', async () => {
+    expect(
+      await ajvFormatsResolver(schema, undefined, { mode: 'sync' })(
+        {},
+        undefined,
+        {
+          fields,
+          shouldUseNativeValidation,
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('should return values from ajvFormatsResolver when format validation pass', async () => {
+    expect(
+      await ajvFormatsResolver(schemaFormat)(validEmail, undefined, {
+        fields,
+        shouldUseNativeValidation,
+      }),
+    ).toEqual({
+      values: validEmail,
+      errors: {},
+    });
+  });
+
+  it('should return error messages from ajvFormatsResolver when format validation fails', async () => {
+    expect(
+      await ajvFormatsResolver(schemaFormat)(invalidEmail, undefined, {
+        fields,
+        shouldUseNativeValidation,
+      }),
+    ).toMatchSnapshot();
+  });
+});

--- a/ajv-formats/src/ajv-formats.ts
+++ b/ajv-formats/src/ajv-formats.ts
@@ -1,0 +1,86 @@
+import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
+import Ajv, { DefinedError } from 'ajv';
+import ajvFormats from 'ajv-formats';
+import ajvErrors from 'ajv-errors';
+import { appendErrors, FieldError } from 'react-hook-form';
+import { Resolver } from './types';
+
+const parseErrorSchema = (
+  ajvErrors: DefinedError[],
+  validateAllFieldCriteria: boolean,
+) => {
+  // Ajv will return empty instancePath when require error
+  ajvErrors.forEach((error) => {
+    if (error.keyword === 'required') {
+      error.instancePath = '/' + error.params.missingProperty;
+    }
+  });
+
+  return ajvErrors.reduce<Record<string, FieldError>>((previous, error) => {
+    // `/deepObject/data` -> `deepObject.data`
+    const path = error.instancePath.substring(1).replace(/\//g, '.');
+
+    if (!previous[path]) {
+      previous[path] = {
+        message: error.message,
+        type: error.keyword,
+      };
+    }
+
+    if (validateAllFieldCriteria) {
+      const types = previous[path].types;
+      const messages = types && types[error.keyword];
+
+      previous[path] = appendErrors(
+        path,
+        validateAllFieldCriteria,
+        previous,
+        error.keyword,
+        messages
+          ? ([] as string[]).concat(messages as string[], error.message || '')
+          : error.message,
+      ) as FieldError;
+    }
+
+    return previous;
+  }, {});
+};
+
+export const ajvFormatsResolver: Resolver =
+  (schema, schemaOptions, resolverOptions = {}) =>
+  async (values, _, options) => {
+    const ajv = new Ajv({
+      allErrors: true,
+      validateSchema: true,
+      ...schemaOptions,
+    });
+
+    ajvErrors(ajv);
+    ajvFormats(ajv);
+
+    const validate = ajv.compile(
+      Object.assign({ $async: resolverOptions?.mode === 'async' }, schema),
+    );
+    const valid = validate(values);
+
+    if (!valid) {
+      return {
+        values: {},
+        errors: toNestError(
+          parseErrorSchema(
+            validate.errors as DefinedError[],
+            !options.shouldUseNativeValidation &&
+              options.criteriaMode === 'all',
+          ),
+          options,
+        ),
+      };
+    }
+
+    options.shouldUseNativeValidation && validateFieldsNatively({}, options);
+
+    return {
+      values,
+      errors: {},
+    };
+  };

--- a/ajv-formats/src/index.ts
+++ b/ajv-formats/src/index.ts
@@ -1,0 +1,2 @@
+export * from './ajv-formats';
+export * from './types';

--- a/ajv-formats/src/types.ts
+++ b/ajv-formats/src/types.ts
@@ -1,0 +1,16 @@
+import {
+  FieldValues,
+  ResolverOptions,
+  ResolverResult,
+} from 'react-hook-form';
+import * as Ajv from 'ajv';
+
+export type Resolver = <T>(
+  schema: Ajv.JSONSchemaType<T>,
+  schemaOptions?: Ajv.Options,
+  factoryOptions?: { mode?: 'async' | 'sync' },
+) => <TFieldValues extends FieldValues, TContext>(
+  values: TFieldValues,
+  context: TContext | undefined,
+  options: ResolverOptions<TFieldValues>,
+) => Promise<ResolverResult<TFieldValues>>;

--- a/config/node-13-exports.js
+++ b/config/node-13-exports.js
@@ -13,6 +13,7 @@ const subRepositories = [
   'computed-types',
   'typanion',
   'ajv',
+  `ajv-formats`,
 ];
 
 const copySrc = () => {

--- a/package.json
+++ b/package.json
@@ -81,6 +81,12 @@
       "import": "./ajv/dist/ajv.mjs",
       "require": "./ajv/dist/ajv.js"
     },
+    "./ajv-formats": {
+      "browser": "./ajv-formats/dist/ajv-formats.module.js",
+      "umd": "./ajv-formats/dist/ajv-formats.umd.js",
+      "import": "./ajv-formats/dist/ajv-formats.mjs",
+      "require": "./ajv-formats/dist/ajv-formats.js"
+    },
     "./package.json": "./package.json",
     "./*": "./*"
   },
@@ -118,7 +124,10 @@
     "typanion/dist",
     "ajv/package.json",
     "ajv/src",
-    "ajv/dist"
+    "ajv/dist",
+    "ajv-formats/package.json",
+    "ajv-formats/src",
+    "ajv-formats/dist"
   ],
   "publishConfig": {
     "access": "public"
@@ -138,6 +147,7 @@
     "build:computed-types": "microbundle --cwd computed-types --globals '@hookform/resolvers=hookformResolvers'",
     "build:typanion": "microbundle --cwd typanion --globals '@hookform/resolvers=hookformResolvers'",
     "build:ajv": "microbundle --cwd ajv --globals '@hookform/resolvers=hookformResolvers'",
+    "build:ajv-formats": "microbundle --cwd ajv-formats --globals '@hookform/resolvers=hookformResolvers'",
     "postbuild": "node ./config/node-13-exports.js",
     "lint": "eslint . --ext .ts,.js --ignore-path .gitignore",
     "lint:types": "tsc",
@@ -162,7 +172,8 @@
     "nope",
     "computed-types",
     "typanion",
-    "ajv"
+    "ajv",
+    "ajv-formats"
   ],
   "repository": {
     "type": "git",
@@ -184,6 +195,7 @@
     "@typescript-eslint/parser": "^5.10.0",
     "ajv": "^8.11.0",
     "ajv-errors": "^3.0.0",
+    "ajv-formats": "^2.1.1",
     "check-export-map": "^1.2.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2019,6 +2019,13 @@ ajv-errors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-3.0.0.tgz#e54f299f3a3d30fe144161e5f0d8d51196c527bc"
   integrity sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==
 
+ajv-formats@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/ajv-formats/-/ajv-formats-2.1.1.tgz#6e669400659eb74973bbf2e33327180a0996b520"
+  integrity sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==
+  dependencies:
+    ajv "^8.0.0"
+
 ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
@@ -2029,20 +2036,20 @@ ajv@^6.10.0, ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^8.0.1:
-  version "8.6.3"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
-  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
+ajv@^8.0.0, ajv@^8.11.0:
+  version "8.11.0"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
+  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
     uri-js "^4.2.2"
 
-ajv@^8.11.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.11.0.tgz#977e91dd96ca669f54a11e23e378e33b884a565f"
-  integrity sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==
+ajv@^8.0.1:
+  version "8.6.3"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-8.6.3.tgz#11a66527761dc3e9a3845ea775d2d3c0414e8764"
+  integrity sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==
   dependencies:
     fast-deep-equal "^3.1.1"
     json-schema-traverse "^1.0.0"


### PR DESCRIPTION
Add ajv-formats custom resolver that is ajv extended with [ajv-formats](https://ajv.js.org/packages/ajv-formats.html).

[ajv-formats](https://github.com/ajv-validator/ajv-formats) makes it easy and secure to validate *emails*, *urls*, *uuids*, and many others string formats.

---
- Follow discussion on https://github.com/react-hook-form/resolvers/pull/430
- Issue: https://github.com/react-hook-form/resolvers/issues/432