### PR TITLE
Remove unnecessary 'browser' exports to fix Jest integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,73 +10,61 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "browser": "./dist/resolvers.module.js",
       "umd": "./dist/resolvers.umd.js",
       "import": "./dist/resolvers.mjs",
       "require": "./dist/resolvers.js"
     },
     "./zod": {
-      "browser": "./zod/dist/zod.module.js",
       "umd": "./zod/dist/zod.umd.js",
       "import": "./zod/dist/zod.mjs",
       "require": "./zod/dist/zod.js"
     },
     "./yup": {
-      "browser": "./yup/dist/yup.module.js",
       "umd": "./yup/dist/yup.umd.js",
       "import": "./yup/dist/yup.mjs",
       "require": "./yup/dist/yup.js"
     },
     "./joi": {
-      "browser": "./joi/dist/joi.module.js",
       "umd": "./joi/dist/joi.umd.js",
       "import": "./joi/dist/joi.mjs",
       "require": "./joi/dist/joi.js"
     },
     "./vest": {
-      "browser": "./vest/dist/vest.module.js",
       "umd": "./vest/dist/vest.umd.js",
       "import": "./vest/dist/vest.mjs",
       "require": "./vest/dist/vest.js"
     },
     "./superstruct": {
-      "browser": "./superstruct/dist/superstruct.module.js",
       "umd": "./superstruct/dist/superstruct.umd.js",
       "import": "./superstruct/dist/superstruct.mjs",
       "require": "./superstruct/dist/superstruct.js"
     },
     "./class-validator": {
-      "browser": "./class-validator/dist/class-validator.module.js",
       "umd": "./class-validator/dist/class-validator.umd.js",
       "import": "./class-validator/dist/class-validator.mjs",
       "require": "./class-validator/dist/class-validator.js"
     },
     "./io-ts": {
-      "browser": "./io-ts/dist/io-ts.module.js",
       "umd": "./io-ts/dist/io-ts.umd.js",
       "import": "./io-ts/dist/io-ts.mjs",
       "require": "./io-ts/dist/io-ts.js"
     },
     "./nope": {
-      "browser": "./nope/dist/nope.module.js",
       "umd": "./nope/dist/nope.umd.js",
       "import": "./nope/dist/nope.mjs",
       "require": "./nope/dist/nope.js"
     },
     "./computed-types": {
-      "browser": "./computed-types/dist/computed-types.module.js",
       "umd": "./computed-types/dist/computed-types.umd.js",
       "import": "./computed-types/dist/computed-types.mjs",
       "require": "./computed-types/dist/computed-types.js"
     },
     "./typanion": {
-      "browser": "./typanion/dist/typanion.module.js",
       "umd": "./typanion/dist/typanion.umd.js",
       "import": "./typanion/dist/typanion.mjs",
       "require": "./typanion/dist/typanion.js"
     },
     "./ajv": {
-      "browser": "./ajv/dist/ajv.module.js",
       "umd": "./ajv/dist/ajv.umd.js",
       "import": "./ajv/dist/ajv.mjs",
       "require": "./ajv/dist/ajv.js"


### PR DESCRIPTION
Fixes #396

This library is exporting multiple builds (umd/module/cjs) but duplicates the CJS ("require") build as the "browser" build. This is not required for this project; "browser" is supposed to be used for distinguishing browser-specific versions (e.g. if using Node `crypto` package when built for NodeJS vs. using browser-standard cryptography when built for browsers), whereas this project does not use any node-specific or browser-specific builds.

Jest's latest update reworks their import handling to properly support package.json `exports`, which has revealed this issue (Jest is now — correctly — using the `browser` import, but failing because it cannot handle esm modules)

By removing the browser entries entirely, all build systems will pick the appropriate build based on whether they want `umd`, `import`, or `require`. This seems to be in line with the original intent of the definitions.

Note also that with this change, the `config/node-13-exports.js` build config could also be changed to _move_ the files instead of copying them, as nothing will require the old `.module.js` versions any more (unless users are importing them directly). I have left this change out to keep things minimal and fully backwards compatible.