### PR TITLE
Added ClassTransformOptions to the resolver

### DIFF
--- a/class-validator/src/class-validator.ts
+++ b/class-validator/src/class-validator.ts
@@ -36,11 +36,12 @@ const parseErrors = (
 export const classValidatorResolver: Resolver =
   (schema, schemaOptions = {}, resolverOptions = {}) =>
   async (values, _, options) => {
-    const user = plainToClass(schema, values);
+    const { transformerOptions, ...restSchemaOptions } = schemaOptions;
+    const user = plainToClass(schema, values, transformerOptions);
 
     const rawErrors = await (resolverOptions.mode === 'sync'
       ? validateSync
-      : validate)(user, schemaOptions);
+      : validate)(user, restSchemaOptions);
 
     if (rawErrors.length) {
       return {

--- a/class-validator/src/types.ts
+++ b/class-validator/src/types.ts
@@ -4,11 +4,13 @@ import {
   ResolverResult,
 } from 'react-hook-form';
 import { ValidatorOptions } from 'class-validator';
-import { ClassConstructor } from 'class-transformer';
+import { ClassConstructor, ClassTransformOptions } from 'class-transformer';
 
 export type Resolver = <T extends { [_: string]: any }>(
   schema: ClassConstructor<T>,
-  schemaOptions?: ValidatorOptions,
+  schemaOptions?: ValidatorOptions & {
+    transformerOptions?: ClassTransformOptions
+  },
   resolverOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
 ) => <TFieldValues extends FieldValues, TContext>(
   values: TFieldValues,


### PR DESCRIPTION
Related issue:
https://github.com/react-hook-form/resolvers/issues/445

Added new attribute to the schemaOptions to include the ClassTransformOptions and give more flexibility to make it possible to add transformation options.