### PR TITLE
feat infer form type from zod schema and fix test

### DIFF
--- a/zod/src/__tests__/Form.tsx
+++ b/zod/src/__tests__/Form.tsx
@@ -10,7 +10,7 @@ const schema = z.object({
   password: z.string().nonempty({ message: 'password field is required' }),
 });
 
-type FormData = z.infer<typeof schema> & { unusedProperty: string };
+type FormData = z.infer<typeof schema>;
 
 interface Props {
   onSubmit: (data: FormData) => void;
@@ -22,7 +22,7 @@ function TestComponent({ onSubmit }: Props) {
     handleSubmit,
     formState: { errors },
   } = useForm<FormData>({
-    resolver: zodResolver(schema), // Useful to check TypeScript regressions
+    resolver: zodResolver(schema),
   });
 
   return (

--- a/zod/src/__tests__/zod.ts
+++ b/zod/src/__tests__/zod.ts
@@ -33,6 +33,7 @@ describe('zodResolver', () => {
   });
 
   it('should return a single error from zodResolver when validation fails', async () => {
+    /// @ts-expect-error invalidData is not matched schema.
     const result = await zodResolver(schema)(invalidData, undefined, {
       fields,
       shouldUseNativeValidation,
@@ -45,9 +46,15 @@ describe('zodResolver', () => {
     const parseSpy = jest.spyOn(schema, 'parse');
     const parseAsyncSpy = jest.spyOn(schema, 'parseAsync');
 
-    const result = await zodResolver(schema, undefined, {
-      mode: 'sync',
-    })(invalidData, undefined, { fields, shouldUseNativeValidation });
+    const result = await zodResolver(schema, undefined, { mode: 'sync' })(
+      /// @ts-expect-error invalidData is not matched schema.
+      invalidData,
+      undefined,
+      {
+        fields,
+        shouldUseNativeValidation,
+      },
+    );
 
     expect(parseSpy).toHaveBeenCalledTimes(1);
     expect(parseAsyncSpy).not.toHaveBeenCalled();
@@ -55,6 +62,7 @@ describe('zodResolver', () => {
   });
 
   it('should return all the errors from zodResolver when validation fails with `validateAllFieldCriteria` set to true', async () => {
+    /// @ts-expect-error invalidData is not matched schema.
     const result = await zodResolver(schema)(invalidData, undefined, {
       fields,
       criteriaMode: 'all',
@@ -66,6 +74,7 @@ describe('zodResolver', () => {
 
   it('should return all the errors from zodResolver when validation fails with `validateAllFieldCriteria` set to true and `mode: sync`', async () => {
     const result = await zodResolver(schema, undefined, { mode: 'sync' })(
+      /// @ts-expect-error invalidData is not matched schema.
       invalidData,
       undefined,
       {

--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -1,8 +1,4 @@
-import {
-  FieldValues,
-  ResolverResult,
-  ResolverOptions,
-} from 'react-hook-form';
+import { Resolver as HookFormResolver } from 'react-hook-form';
 import { z } from 'zod';
 
 export type Resolver = <T extends z.Schema<any, any>>(
@@ -19,8 +15,4 @@ export type Resolver = <T extends z.Schema<any, any>>(
      */
     rawValues?: boolean;
   },
-) => <TFieldValues extends FieldValues, TContext>(
-  values: TFieldValues,
-  context: TContext | undefined,
-  options: ResolverOptions<TFieldValues>,
-) => Promise<ResolverResult<TFieldValues>>;
+) => HookFormResolver<z.input<T>>;


### PR DESCRIPTION
- feat infer FormType from zod schema without using type assertion
```ts
const HogeSchema = z.object({
  name: z.string(),
  age: z.number(),
});

const _ = useForm({ resolver: zodResolver(HogeSchema) });
// _ is UseFormReturn<{ name: string; age: number }>

_.watch("age") // work! it is number 
_.watch("name") // work! it is string
```

- fix type error in test



I referred to #417, thanks @maddijoyce !
