### PR TITLE
remove $ from script that is copyable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 ## Install
 
-    $ npm install @hookform/resolvers
+    npm install @hookform/resolvers
 
 ## Links
 


### PR DESCRIPTION
GitHub site adds a copy to clipboard button to code samples. Having the `$` makes it invalid to paste. Remove it.