### PR TITLE
minor typo fix in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ import React from 'react';
 import { useForm } from 'react-hook-form';
 import { ioTsResolver } from '@hookform/resolvers/io-ts';
 import t from 'io-ts';
-// you don't have to use io-ts-types but it's very useful
+// you don't have to use io-ts-types, but it's very useful
 import tt from 'io-ts-types';
 
 const schema = t.type({


### PR DESCRIPTION
Adding it solely because my IDE spellchecked harassed me and distracted me a bit when I copy-pasted the example. 

Don't want anybody to be distracted by their spellchecker as I had 😄 

<img width="114" alt="Screenshot 2023-01-22 at 7 51 47 PM" src="https://user-images.githubusercontent.com/947595/213916811-648cf1d3-d760-49c3-80db-be7343246dbd.png">
