### PR TITLE
Fix ts-io resolver error reporting for exact(intersection(...))

### DIFF
--- a/io-ts/src/__tests__/errorsToRecord.ts
+++ b/io-ts/src/__tests__/errorsToRecord.ts
@@ -8,9 +8,10 @@ const assertLeft = <T>(result: t.Validation<T>) => {
   return result.left;
 };
 
+const FIRST_NAME_FIELD_PATH = 'firstName' as const;
+const FIRST_NAME_ERROR_SHAPE = {message: 'expected string but got undefined', type: 'string'};
 describe('errorsToRecord', () => {
   it('should return a correct error for an exact intersection type error object', () => {
-    const FIRST_NAME_FIELD_PATH = 'firstName' as const;
     // a recommended pattern from https://github.com/gcanti/io-ts/blob/master/index.md#mixing-required-and-optional-props
     const schema = t.exact(t.intersection([
       t.type({
@@ -22,6 +23,25 @@ describe('errorsToRecord', () => {
     ]));
     const error = assertLeft(schema.decode({}));
     const record = errorsToRecord(false)(error);
-    expect(record[FIRST_NAME_FIELD_PATH]).toMatchObject({message: 'expected string but got undefined', type: 'string'});
+    expect(record[FIRST_NAME_FIELD_PATH]).toMatchObject(FIRST_NAME_ERROR_SHAPE);
   });
+  it('should return a correct error for a branded intersection', () => {
+    interface Brand {
+      readonly Brand: unique symbol
+    }
+    const schema = t.brand(t.intersection([
+        t.type({
+          [FIRST_NAME_FIELD_PATH]: t.string
+        }),
+        t.type({
+          lastName: t.string
+        })
+      ]),
+      (_x): _x is t.Branded<typeof _x, Brand> => true,
+      'Brand'
+    );
+    const error = assertLeft(schema.decode({}));
+    const record = errorsToRecord(false)(error);
+    expect(record[FIRST_NAME_FIELD_PATH]).toMatchObject(FIRST_NAME_ERROR_SHAPE);
+  })
 });

--- a/io-ts/src/__tests__/errorsToRecord.ts
+++ b/io-ts/src/__tests__/errorsToRecord.ts
@@ -2,7 +2,7 @@ import * as t from 'io-ts';
 import { isLeft } from 'fp-ts/Either';
 import errorsToRecord from '../errorsToRecord';
 
-const assertLeft = (result: t.Validation<any>) => {
+const assertLeft = <T>(result: t.Validation<T>) => {
   expect(isLeft(result)).toBe(true);
   if (!isLeft(result)) {throw new Error('panic! error is not of the "left" type, should be unreachable');}
   return result.left;
@@ -21,7 +21,7 @@ describe('errorsToRecord', () => {
       })
     ]));
     const error = assertLeft(schema.decode({}));
-    const record = errorsToRecord(false)(error)
-    expect(record[FIRST_NAME_FIELD_PATH]).toMatchObject({message: 'expected string but got undefined', type: 'string'})
+    const record = errorsToRecord(false)(error);
+    expect(record[FIRST_NAME_FIELD_PATH]).toMatchObject({message: 'expected string but got undefined', type: 'string'});
   });
 });

--- a/io-ts/src/__tests__/errorsToRecord.ts
+++ b/io-ts/src/__tests__/errorsToRecord.ts
@@ -1,0 +1,27 @@
+import * as t from 'io-ts';
+import { isLeft } from 'fp-ts/Either';
+import errorsToRecord from '../errorsToRecord';
+
+const assertLeft = (result: t.Validation<any>) => {
+  expect(isLeft(result)).toBe(true);
+  if (!isLeft(result)) {throw new Error('panic! error is not of the "left" type, should be unreachable');}
+  return result.left;
+};
+
+describe('errorsToRecord', () => {
+  it('should return a correct error for an exact intersection type error object', () => {
+    const FIRST_NAME_FIELD_PATH = 'firstName' as const;
+    // a recommended pattern from https://github.com/gcanti/io-ts/blob/master/index.md#mixing-required-and-optional-props
+    const schema = t.exact(t.intersection([
+      t.type({
+        [FIRST_NAME_FIELD_PATH]: t.string
+      }),
+      t.partial({
+        lastName: t.string
+      })
+    ]));
+    const error = assertLeft(schema.decode({}));
+    const record = errorsToRecord(false)(error)
+    expect(record[FIRST_NAME_FIELD_PATH]).toMatchObject({message: 'expected string but got undefined', type: 'string'})
+  });
+});

--- a/io-ts/src/errorsToRecord.ts
+++ b/io-ts/src/errorsToRecord.ts
@@ -1,7 +1,7 @@
 import * as t from 'io-ts';
 import {
   ExactType,
-  IntersectionType,
+  IntersectionType, RefinementType,
   TaggedUnionType,
   UnionType,
   ValidationError
@@ -15,7 +15,7 @@ import arrayToPath from './arrayToPath';
 import * as ReadonlyRecord from 'fp-ts/ReadonlyRecord';
 import { ErrorObject, FieldErrorWithPath } from './types';
 
-const INSTANCE_TYPES_TO_FILTER = [TaggedUnionType, UnionType, IntersectionType, ExactType];
+const INSTANCE_TYPES_TO_FILTER = [TaggedUnionType, UnionType, IntersectionType, ExactType, RefinementType];
 const formatErrorPath = (context: t.Context): string =>
   pipe(
     context,
@@ -24,7 +24,7 @@ const formatErrorPath = (context: t.Context): string =>
       const previousContextEntry = previousIndex === -1 ? undefined : context[previousIndex];
       const shouldBeFiltered =
         previousContextEntry === undefined ||
-        INSTANCE_TYPES_TO_FILTER.some((type) => previousContextEntry.type instanceof type);
+        INSTANCE_TYPES_TO_FILTER.some((type) => previousContextEntry.type instanceof type)
 
       return shouldBeFiltered ? Option.none : Option.some(contextEntry);
     }),

--- a/io-ts/src/errorsToRecord.ts
+++ b/io-ts/src/errorsToRecord.ts
@@ -1,9 +1,10 @@
 import * as t from 'io-ts';
 import {
+  ExactType,
   IntersectionType,
   TaggedUnionType,
   UnionType,
-  ValidationError,
+  ValidationError
 } from 'io-ts';
 import { absurd, flow, identity, not, pipe } from 'fp-ts/function';
 import * as ReadonlyArray from 'fp-ts/ReadonlyArray';
@@ -14,17 +15,16 @@ import arrayToPath from './arrayToPath';
 import * as ReadonlyRecord from 'fp-ts/ReadonlyRecord';
 import { ErrorObject, FieldErrorWithPath } from './types';
 
+const INSTANCE_TYPES_TO_FILTER = [TaggedUnionType, UnionType, IntersectionType, ExactType];
 const formatErrorPath = (context: t.Context): string =>
   pipe(
     context,
     ReadonlyArray.filterMapWithIndex((index, contextEntry) => {
       const previousIndex = index - 1;
-
+      const previousContextEntry = previousIndex === -1 ? undefined : context[previousIndex];
       const shouldBeFiltered =
-        context[previousIndex] === undefined ||
-        context[previousIndex].type instanceof TaggedUnionType ||
-        context[previousIndex].type instanceof UnionType ||
-        context[previousIndex].type instanceof IntersectionType;
+        previousContextEntry === undefined ||
+        INSTANCE_TYPES_TO_FILTER.some((type) => previousContextEntry.type instanceof type);
 
       return shouldBeFiltered ? Option.none : Option.some(contextEntry);
     }),

--- a/io-ts/src/errorsToRecord.ts
+++ b/io-ts/src/errorsToRecord.ts
@@ -1,7 +1,8 @@
 import * as t from 'io-ts';
 import {
   ExactType,
-  IntersectionType, RefinementType,
+  IntersectionType,
+  RefinementType,
   TaggedUnionType,
   UnionType,
   ValidationError

--- a/yarn.lock
+++ b/yarn.lock
@@ -2438,15 +2438,15 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001243, caniuse-lite@^1.0.30001248:
-  version "1.0.30001249"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001249.tgz#90a330057f8ff75bfe97a94d047d5e14fabb2ee8"
-  integrity sha512-vcX4U8lwVXPdqzPWi6cAJ3FnQaqXbBqy/GZseKNQzRj37J7qZdGcBtxq/QLFNLLlfsoXLUdHw8Iwenri86Tagw==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001243, caniuse-lite@^1.0.30001248, caniuse-lite@^1.0.30001286:
+  version "1.0.30001449"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz"
+  integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
 
-caniuse-lite@^1.0.30001286:
-  version "1.0.30001300"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001300.tgz#11ab6c57d3eb6f964cba950401fd00a146786468"
-  integrity sha512-cVjiJHWGcNlJi8TZVKNMnvMid3Z3TTdDHmLDzlOdIiZq138Exvo0G+G0wTdVYolxKb4AYwC+38pxodiInVtJSA==
+caniuse-lite@^1.0.30001449:
+  version "1.0.30001449"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001449.tgz#a8d11f6a814c75c9ce9d851dc53eb1d1dfbcd657"
+  integrity sha512-CPB+UL9XMT/Av+pJxCKGhdx+yg1hzplvFJQlJ2n68PyQGMz9L/E2zCyLdOL8uasbouTUgnPl+y0tccI/se+BEw==
 
 chalk@^1.0.0, chalk@^1.1.3:
   version "1.1.3"


### PR DESCRIPTION
`exact(intersection(...))` structure would result in an undesirable result of a shape`{0: errorsRecord, 1: errorsRecord, ...}` whereas just exact(...) or just intersection(...) would correctly report errors of shape `errorsRecord`. 

This PR adds a test against it and resolves the bug.

UPD: same for Branded types

Bonus: caniuse-lite bumped a bit in package-lock