### PR TITLE
fix(vest): add types export

### DIFF
--- a/vest/src/index.ts
+++ b/vest/src/index.ts
@@ -1,1 +1,2 @@
 export * from './vest';
+export * from './types';


### PR DESCRIPTION
Types export is missing for `vest` resolver.