### PR TITLE
Throw any error unrelated to Zod

### DIFF
--- a/zod/src/__tests__/zod.ts
+++ b/zod/src/__tests__/zod.ts
@@ -77,4 +77,16 @@ describe('zodResolver', () => {
 
     expect(result).toMatchSnapshot();
   });
+
+  it('should throw any error unrelated to Zod', async () => {
+    const schemaWithCustomError = schema.refine(() => {
+      throw Error('custom error');
+    });
+    const promise = zodResolver(schemaWithCustomError)(validData, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    await expect(promise).rejects.toThrow('custom error');
+  });
 });

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -3,7 +3,7 @@ import {
   FieldError,
   FieldErrors,
 } from 'react-hook-form';
-import { z } from 'zod';
+import { z, ZodError } from 'zod';
 import { toNestError, validateFieldsNatively } from '@hookform/resolvers';
 import type { Resolver } from './types';
 
@@ -72,18 +72,22 @@ export const zodResolver: Resolver =
           values: resolverOptions.rawValues ? values : data,
         };
       } catch (error: any) {
-        return {
-          values: {},
-          errors: error.isEmpty
-            ? {}
-            : toNestError(
-              parseErrorSchema(
-                error.errors,
-                !options.shouldUseNativeValidation &&
-                options.criteriaMode === 'all',
+        if (error instanceof ZodError) {
+          return {
+            values: {},
+            errors: error.isEmpty
+              ? {}
+              : toNestError(
+                parseErrorSchema(
+                  error.errors,
+                  !options.shouldUseNativeValidation &&
+                  options.criteriaMode === 'all',
+                ),
+                options,
               ),
-              options,
-            ),
-        };
+          };
+        }
+
+        throw error;
       }
     };


### PR DESCRIPTION
This pull request makes sure that errors that are not of type `ZodError` are thrown. It's possible for errors other than `ZodError` to occur when using things like `.refine` (for instance by referencing the property of a non-existent item in an array). Currently, when this happens, you get the following error:
>TypeError: undefined is not an object (evaluating 'e.length')

This took me a long time to debug today, because it was not clear where this error was coming from, nor was it very descriptive. Hopefully this change will save someone's time in the future!

Please let me know if any changes are necessary. I'll gladly update the pull request.