### PR TITLE
ci: add NPM_TOKEN

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,16 +66,12 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
+
       - name: Build
         run: pnpm build
-
-      - name: Npm token
-        run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
-        env:
-          NPM_TOKEN: '${{secrets.NPM_TOKEN}}'
 
       - name: Publish
         run: npx semantic-release
         env:
-          NODE_AUTH_TOKEN: '${{secrets.NPM_TOKEN}}'
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_TOKEN: '${{secrets.GITHUB_TOKEN}}'


### PR DESCRIPTION
According to the doc, the right way to provide the NPM TOken: https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#.github-workflows-release.yml-configuration-for-node-projects