### PR TITLE
feat: pass `options.names` as a second argument to a Vest suite

### DIFF
--- a/vest/src/__tests__/vest.ts
+++ b/vest/src/__tests__/vest.ts
@@ -68,4 +68,17 @@ describe('vestResolver', () => {
       ),
     ).toMatchSnapshot();
   });
+
+  it('should call a suite with values, validated field names and a context as arguments', async () => {
+    const suite = vi.fn(validationSuite) as any as typeof validationSuite;
+
+    await vestResolver(suite)(validData, { some: 'context' }, {
+      fields: { username: fields.username },
+      names: ['username'],
+      shouldUseNativeValidation,
+    });
+
+    expect(suite).toHaveBeenCalledTimes(1);
+    expect(suite).toHaveBeenCalledWith(validData, ['username'], { some: 'context' });
+  });
 });

--- a/vest/src/types.ts
+++ b/vest/src/types.ts
@@ -1,20 +1,23 @@
 import {
   FieldValues,
+  FieldName,
   ResolverOptions,
   ResolverResult,
 } from 'react-hook-form';
 import * as Vest from 'vest';
 
-export type ICreateResult = ReturnType<typeof Vest.create>;
+export type ICreateResult<TValues extends FieldValues = FieldValues, TContext = any> = ReturnType<
+  typeof Vest.create<(values: TValues, names?: FieldName<TValues>[], context?: TContext) => void>
+>;
 
-export type Resolver = (
-  schema: ICreateResult,
+export type Resolver = <TValues extends FieldValues, TContext>(
+  schema: ICreateResult<TValues, TContext>,
   schemaOptions?: never,
   factoryOptions?: { mode?: 'async' | 'sync', rawValues?: boolean; },
-) => <TFieldValues extends FieldValues, TContext>(
-  values: TFieldValues,
+) => (
+  values: TValues,
   context: TContext | undefined,
-  options: ResolverOptions<TFieldValues>,
-) => Promise<ResolverResult<TFieldValues>>;
+  options: ResolverOptions<TValues>,
+) => Promise<ResolverResult<TValues>>;
 
 export type VestErrors = Record<string, string[]>;

--- a/vest/src/vest.ts
+++ b/vest/src/vest.ts
@@ -25,11 +25,11 @@ const parseErrorSchema = (
 
 export const vestResolver: Resolver =
   (schema, _, resolverOptions = {}) =>
-  async (values, _context, options) => {
+  async (values, context, options) => {
     const result =
       resolverOptions.mode === 'sync'
-        ? schema(values)
-        : await promisify(schema)(values);
+        ? schema(values, options.names, context)
+        : await promisify(schema)(values, options.names, context);
 
     if (result.hasErrors()) {
       return {


### PR DESCRIPTION
React Hook Form has a way to signal to a resolver for which fields validations were requested (`options.names`/`options.fields`) and Vest has a way to skip unrequested validations (`only`/`skip`/`include`). But currently that names information gets discarded and Vest cannot utilize that functionality. I think it makes sense to pass names as a second argument.

Note: `vestResolver` has a second argument which is and never was utilized, other adapters do not have such thing. I think it should be put on note somewhere for removal in next major release.