### PR TITLE
fix(zod): allow inferring specific `Resolver` type from `zodResolver`

### DIFF
--- a/zod/src/types.ts
+++ b/zod/src/types.ts
@@ -1,22 +1,4 @@
-import { FieldValues, ResolverResult, ResolverOptions } from 'react-hook-form';
-import { z } from 'zod';
+import type { zodResolver } from './zod';
 
-export type Resolver = <T extends z.Schema<any, any>>(
-  schema: T,
-  schemaOptions?: Partial<z.ParseParams>,
-  factoryOptions?: {
-    /**
-     * @default async
-     */
-    mode?: 'async' | 'sync';
-    /**
-     * Return the raw input values rather than the parsed values.
-     * @default false
-     */
-    raw?: boolean;
-  },
-) => <TFieldValues extends FieldValues, TContext>(
-  values: TFieldValues,
-  context: TContext | undefined,
-  options: ResolverOptions<TFieldValues>,
-) => Promise<ResolverResult<TFieldValues>>;
+
+export type Resolver = ReturnType<typeof zodResolver>


### PR DESCRIPTION
# Summary

Allows the result of `zodResolver` to infer the schema shape, based on the zod schema it's been passed. This matches the behavior of [the similar `yupResolver`](https://github.com/react-hook-form/resolvers/blob/3805d3eeae950ba6540f5d79d264c49287008d6a/yup/src/yup.ts#L61), as implemented in #563 

Resolves #429, #447, #551