### PR TITLE
Valibot infinate loop in resolver

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "superstruct": "^1.0.3",
     "typanion": "^3.14.0",
     "typescript": "^5.1.6",
-    "valibot": "^0.12.0",
+    "valibot": "^0.24.1",
     "vest": "^4.6.11",
     "vite": "^4.4.9",
     "vite-tsconfig-paths": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,8 +126,8 @@ devDependencies:
     specifier: ^5.1.6
     version: 5.1.6
   valibot:
-    specifier: ^0.12.0
-    version: 0.12.0
+    specifier: ^0.24.1
+    version: 0.24.1
   vest:
     specifier: ^4.6.11
     version: 4.6.11
@@ -6239,8 +6239,8 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /valibot@0.12.0:
-    resolution: {integrity: sha512-EGx/uDUpRa9wB9NkD7fsktc02rvXWlJzDTC/ihbE+NybhzAsMhns2OOdNv2R4BtdGnDvaCEGi/DbgR5RvgCS8A==}
+  /valibot@0.24.1:
+    resolution: {integrity: sha512-Toclbuy20XsECZiueh2dkQ63he2AGaBIj/FJRDAFti2kueFldm9bjJzSYvPaL5CE1HXDMRhq7olak8at7xCz5A==}
     dev: true
 
   /validate-npm-package-license@3.0.4:

--- a/valibot/src/__tests__/Form-native-validation.tsx
+++ b/valibot/src/__tests__/Form-native-validation.tsx
@@ -42,7 +42,7 @@ function TestComponent({ onSubmit }: Props) {
   );
 }
 
-test("form's native validation with Zod", async () => {
+test("form's native validation with Valibot", async () => {
   const handleSubmit = vi.fn();
   render(<TestComponent onSubmit={handleSubmit} />);
 

--- a/valibot/src/__tests__/__fixtures__/data.ts
+++ b/valibot/src/__tests__/__fixtures__/data.ts
@@ -12,7 +12,9 @@ import {
   array,
   boolean,
   required,
-  union
+  union,
+  variant,
+  literal,
 } from 'valibot';
 
 export const schema = required(
@@ -29,7 +31,13 @@ export const schema = required(
       minLength(8, 'Must be at least 8 characters in length'),
     ]),
     repeatPassword: string('Repeat Password is required'),
-    accessToken: union([string('Access token should be a string'), number('Access token  should be a number')], "access token is required"),
+    accessToken: union(
+      [
+        string('Access token should be a string'),
+        number('Access token  should be a number'),
+      ],
+      'access token is required',
+    ),
     birthYear: number('Please enter your birth year', [
       minValue(1900),
       maxValue(2013),
@@ -45,6 +53,14 @@ export const schema = required(
     ),
   }),
 );
+
+export const schemaError = variant('type', [
+  object({ type: literal('a') }),
+  object({ type: literal('b') }),
+]);
+
+export const validSchemaErrorData = { type: 'a' };
+export const invalidSchemaErrorData = { type: 'c' };
 
 export const validData = {
   username: 'Doe',

--- a/valibot/src/__tests__/valibot.ts
+++ b/valibot/src/__tests__/valibot.ts
@@ -1,6 +1,14 @@
 /* eslint-disable no-console, @typescript-eslint/ban-ts-comment */
 import { valibotResolver } from '..';
-import { schema, validData, fields, invalidData } from './__fixtures__/data';
+import {
+  schema,
+  validData,
+  fields,
+  invalidData,
+  schemaError,
+  validSchemaErrorData,
+  invalidSchemaErrorData,
+} from './__fixtures__/data';
 import * as valibot from 'valibot';
 
 const shouldUseNativeValidation = false;
@@ -97,5 +105,35 @@ describe('valibotResolver', () => {
     );
 
     expect(result).toMatchSnapshot();
+  });
+
+  it('should be able to validate variants', async () => {
+    const result = await valibotResolver(schemaError, undefined, {
+      mode: 'sync',
+    })(validSchemaErrorData, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    expect(result).toEqual({
+      errors: {},
+      values: {
+        type: 'a',
+      },
+    });
+  });
+
+  it('should exit issue resolution if no path is set', async () => {
+    const result = await valibotResolver(schemaError, undefined, {
+      mode: 'sync',
+    })(invalidSchemaErrorData, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    expect(result).toEqual({
+      errors: {},
+      values: {},
+    });
   });
 });

--- a/valibot/src/valibot.ts
+++ b/valibot/src/valibot.ts
@@ -13,8 +13,8 @@ const parseErrors = (
   validateAllFieldCriteria: boolean,
 ): FieldErrors => {
   const errors: Record<string, FieldError> = {};
-  for (; valiErrors.issues.length; ) {
-    const error = valiErrors.issues[0];
+
+  for (const error of valiErrors.issues) {
     if (!error.path) {
       continue;
     }
@@ -38,8 +38,6 @@ const parseErrors = (
           : error.message,
       ) as FieldError;
     }
-
-    valiErrors.issues.shift();
   }
 
   return errors;


### PR DESCRIPTION
**Describe the bug**
In recent versions of valibot they've introduced a `variant` method. This method does not set a `path` value in the issues array. Because of the way the `valibotResolver` loops over the issues returned from valibot, this can cause an infinite loop.

**To Reproduce**

1. Using the following schema:

```ts
const numberSchema = object({
  type: literal("number")
})

const stringSchema = object({
  type: literal("string")
})

const typeSchema = variant("type", [numberSchema, stringSchema])
```

2. Try to call the valibot resolver.

```ts
const data = {
  type: undefined
}

await valibotResolver(typeSchema, undefined, {
  mode: 'sync',
})(data, undefined, {
  fields,
  shouldUseNativeValidation,
});
```

3. Browser or test runner freezes.

**Additional context**

I've included tests in this PR. If you wish to demonstrate the issue you can revert the changes I made to `valibot.ts`.

Because there's no path returned from valibot we can't add the error to the resolver. I've requested a change in valibot to address this and the author [seems to agree](https://github.com/fabian-hiller/valibot/issues/303). This PR simply fixes the infinite loop and I will submit a second once the other issue has been addressed to update the dependency to the fixed version.

I've tried to follow the contributing guidelines as best as I can. It seems as they're out of date or were copied from somewhere else the following commands listed aren't in this repo as far as I can tell:

* tsd
* e2e
* start
* api-extractor