### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -554,11 +554,12 @@ import { valibotResolver } from '@hookform/resolvers/valibot';
 import { object, string, minLength, endsWith } from 'valibot';
 
 const schema = object({
-  username: string('username is required', [
+  username: string([
+    minLength(1, 'username is required'),
     minLength(3, 'Needs to be at least 3 characters'),
     endsWith('cool', 'Needs to end with `cool`'),
   ]),
-  password: string('password is required'),
+  password: string([minLength(1,'password is required')]),
 });
 
 const App = () => {


### PR DESCRIPTION
From the Doc of valibot, the optional message is just apply when the type is not `string`, instead of using as 'required'. So the original is misleading. https://valibot.dev/api/string/