### PR TITLE
feat: add support for custom error messages for required fields

### DIFF
--- a/ajv/src/__tests__/__fixtures__/data.ts
+++ b/ajv/src/__tests__/__fixtures__/data.ts
@@ -39,6 +39,48 @@ export const schema: JSONSchemaType<Data> = {
   additionalProperties: false,
 };
 
+export const errorMessageSchema: JSONSchemaType<Data> = {
+  type: 'object',
+  properties: {
+    username: {
+      type: 'string',
+      minLength: 3,
+    },
+    password: {
+      type: 'string',
+      pattern: '.*[A-Z].*',
+      errorMessage: {
+        pattern: 'One uppercase character',
+      },
+    },
+    deepObject: {
+      type: 'object',
+      properties: {
+        data: { type: 'string' },
+        twoLayersDeep: {
+          type: 'object',
+          properties: { name: { type: 'string' } },
+          additionalProperties: false,
+          required: ['name'],
+        },
+      },
+      required: ['data', 'twoLayersDeep'],
+      errorMessage: {
+        required: {
+          data: 'Data is required',
+        },
+      },
+    },
+  },
+  required: ['username', 'password', 'deepObject'],
+  additionalProperties: false,
+  errorMessage: {
+    required: {
+      password: 'Password is required',
+    },
+  },
+};
+
 export const validData: Data = {
   username: 'jsun969',
   password: 'validPassword',

--- a/ajv/src/__tests__/__fixtures__/data.ts
+++ b/ajv/src/__tests__/__fixtures__/data.ts
@@ -62,6 +62,11 @@ export const errorMessageSchema: JSONSchemaType<Data> = {
           properties: { name: { type: 'string' } },
           additionalProperties: false,
           required: ['name'],
+          errorMessage: {
+            required: {
+              name: 'Name is required',
+            },
+          },
         },
       },
       required: ['data', 'twoLayersDeep'],
@@ -107,6 +112,17 @@ export const invalidDataWithUndefined = {
   deepObject: {
     twoLayersDeep: {
       name: 'deeper',
+    },
+    data: undefined,
+  },
+};
+
+export const invalidDataWithAllUndefined = {
+  username: undefined,
+  password: undefined,
+  deepObject: {
+    twoLayersDeep: {
+      name: undefined,
     },
     data: undefined,
   },

--- a/ajv/src/__tests__/__snapshots__/ajv.ts.snap
+++ b/ajv/src/__tests__/__snapshots__/ajv.ts.snap
@@ -1,5 +1,41 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ajvResolver > should return all the custom and native error messages from ajvResolver when properties are undefined and result will keep the input data structure 1`] = `
+{
+  "errors": {
+    "deepObject": {
+      "data": {
+        "message": "Data is required",
+        "ref": undefined,
+        "type": "errorMessage",
+      },
+      "twoLayersDeep": {
+        "name": {
+          "message": "Name is required",
+          "ref": undefined,
+          "type": "errorMessage",
+        },
+      },
+    },
+    "password": {
+      "message": "Password is required",
+      "ref": {
+        "name": "password",
+      },
+      "type": "errorMessage",
+    },
+    "username": {
+      "message": "must have required property 'username'",
+      "ref": {
+        "name": "username",
+      },
+      "type": "required",
+    },
+  },
+  "values": {},
+}
+`;
+
 exports[`ajvResolver > should return all the custom error messages from ajvResolver when some property is undefined and result will keep the input data structure 1`] = `
 {
   "errors": {

--- a/ajv/src/__tests__/__snapshots__/ajv.ts.snap
+++ b/ajv/src/__tests__/__snapshots__/ajv.ts.snap
@@ -1,5 +1,27 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ajvResolver > should return all the custom error messages from ajvResolver when some property is undefined and result will keep the input data structure 1`] = `
+{
+  "errors": {
+    "deepObject": {
+      "data": {
+        "message": "Data is required",
+        "ref": undefined,
+        "type": "errorMessage",
+      },
+    },
+    "password": {
+      "message": "Password is required",
+      "ref": {
+        "name": "password",
+      },
+      "type": "errorMessage",
+    },
+  },
+  "values": {},
+}
+`;
+
 exports[`ajvResolver > should return all the error messages from ajvResolver when requirement fails and validateAllFieldCriteria set to true 1`] = `
 {
   "errors": {

--- a/ajv/src/__tests__/ajv.ts
+++ b/ajv/src/__tests__/ajv.ts
@@ -6,6 +6,7 @@ import {
   schema,
   validData,
   errorMessageSchema,
+  invalidDataWithAllUndefined,
 } from './__fixtures__/data';
 
 const shouldUseNativeValidation = false;
@@ -106,6 +107,19 @@ describe('ajvResolver', () => {
     expect(
       await ajvResolver(errorMessageSchema, undefined, { mode: 'sync' })(
         invalidDataWithUndefined,
+        undefined,
+        {
+          fields,
+          shouldUseNativeValidation,
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('should return all the custom and native error messages from ajvResolver when properties are undefined and result will keep the input data structure', async () => {
+    expect(
+      await ajvResolver(errorMessageSchema, undefined, { mode: 'sync' })(
+        invalidDataWithAllUndefined,
         undefined,
         {
           fields,

--- a/ajv/src/__tests__/ajv.ts
+++ b/ajv/src/__tests__/ajv.ts
@@ -1,5 +1,12 @@
 import { ajvResolver } from '..';
-import { fields, invalidData, invalidDataWithUndefined, schema, validData } from './__fixtures__/data';
+import {
+  fields,
+  invalidData,
+  invalidDataWithUndefined,
+  schema,
+  validData,
+  errorMessageSchema,
+} from './__fixtures__/data';
 
 const shouldUseNativeValidation = false;
 
@@ -85,6 +92,19 @@ describe('ajvResolver', () => {
   it('should return all the error messages from ajvResolver when some property is undefined and result will keep the input data structure', async () => {
     expect(
       await ajvResolver(schema, undefined, { mode: 'sync' })(
+        invalidDataWithUndefined,
+        undefined,
+        {
+          fields,
+          shouldUseNativeValidation,
+        },
+      ),
+    ).toMatchSnapshot();
+  });
+
+  it('should return all the custom error messages from ajvResolver when some property is undefined and result will keep the input data structure', async () => {
+    expect(
+      await ajvResolver(errorMessageSchema, undefined, { mode: 'sync' })(
         invalidDataWithUndefined,
         undefined,
         {

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -1,17 +1,104 @@
-import { toNestErrors, validateFieldsNatively } from '@hookform/resolvers';
-import Ajv, { DefinedError } from 'ajv';
+import {
+  toNestErrors,
+  validateFieldsNatively,
+  isObject,
+} from '@hookform/resolvers';
+import Ajv, { DefinedError, ErrorObject } from 'ajv';
 import ajvErrors from 'ajv-errors';
 import { appendErrors, FieldError } from 'react-hook-form';
 import { Resolver } from './types';
 
-const parseErrorSchema = (
-  ajvErrors: DefinedError[],
+// const parseErrorSchema = (
+//   ajvErrors: DefinedError[],
+//   validateAllFieldCriteria: boolean,
+// ) => {
+//   // Ajv will return empty instancePath when require error
+//   ajvErrors.forEach((error) => {
+//     if (error.keyword === 'required') {
+//       error.instancePath += '/' + error.params.missingProperty;
+//     }
+//   });
+
+//   return ajvErrors.reduce<Record<string, FieldError>>((previous, error) => {
+//     // `/deepObject/data` -> `deepObject.data`
+//     const path = error.instancePath.substring(1).replace(/\//g, '.');
+
+//     if (!previous[path]) {
+//       previous[path] = {
+//         message: error.message,
+//         type: error.keyword,
+//       };
+//     }
+
+//     if (validateAllFieldCriteria) {
+//       const types = previous[path].types;
+//       const messages = types && types[error.keyword];
+
+//       previous[path] = appendErrors(
+//         path,
+//         validateAllFieldCriteria,
+//         previous,
+//         error.keyword,
+//         messages
+//           ? ([] as string[]).concat(messages as string[], error.message || '')
+//           : error.message,
+//       ) as FieldError;
+//     }
+
+//     return previous;
+//   }, {});
+// };
+
+const customParseErrorSchema = (
+  ajvErrors: ErrorObject[],
   validateAllFieldCriteria: boolean,
 ) => {
-  // Ajv will return empty instancePath when require error
-  ajvErrors.forEach((error) => {
+  ajvErrors?.forEach((error) => {
     if (error.keyword === 'required') {
       error.instancePath += '/' + error.params.missingProperty;
+    }
+
+    if (error.keyword === 'errorMessage') {
+      const typedParams = error.params as unknown;
+      let isRequiredErrorInParams: Record<string, unknown> | false = false;
+
+      if (
+        isObject<Record<string, unknown>>(typedParams) &&
+        typedParams.errors
+      ) {
+        const typedErrors = typedParams.errors as unknown;
+
+        if (Array.isArray(typedErrors)) {
+          isRequiredErrorInParams = typedErrors.find((error: unknown) => {
+            if (isObject<Record<string, unknown>>(error)) {
+              const typedErrorParams = error.params;
+
+              if (
+                isObject<Record<string, unknown>>(typedErrorParams) &&
+                typedErrorParams.missingProperty &&
+                error.keyword === 'required'
+              ) {
+                return true;
+              }
+
+              return false;
+            }
+
+            return false;
+          });
+        }
+      }
+
+      if (
+        isRequiredErrorInParams &&
+        isObject<Record<string, unknown>>(isRequiredErrorInParams) &&
+        isRequiredErrorInParams.params &&
+        isObject<Record<string, unknown>>(isRequiredErrorInParams.params) &&
+        isRequiredErrorInParams.params.missingProperty
+      ) {
+        error.instancePath +=
+          '/' + isRequiredErrorInParams.params.missingProperty;
+      }
     }
   });
 
@@ -77,7 +164,7 @@ export const ajvResolver: Resolver =
       : {
           values: {},
           errors: toNestErrors(
-            parseErrorSchema(
+            customParseErrorSchema(
               validate.errors as DefinedError[],
               !options.shouldUseNativeValidation &&
                 options.criteriaMode === 'all',
@@ -85,4 +172,18 @@ export const ajvResolver: Resolver =
             options,
           ),
         };
+
+    // return valid
+    //   ? { values, errors: {} }
+    //   : {
+    //       values: {},
+    //       errors: toNestErrors(
+    //         parseErrorSchema(
+    //           validate.errors as DefinedError[],
+    //           !options.shouldUseNativeValidation &&
+    //             options.criteriaMode === 'all',
+    //         ),
+    //         options,
+    //       ),
+    //     };
   };

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -50,7 +50,8 @@ const parseErrorSchema = (
   ajvErrors: ErrorObject[],
   validateAllFieldCriteria: boolean,
 ) => {
-  ajvErrors?.forEach((error) => {
+  // Ajv will return empty instancePath when require error
+  ajvErrors.forEach((error) => {
     if (error.keyword === 'required') {
       error.instancePath += '/' + error.params.missingProperty;
     }

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -22,17 +22,16 @@ type RequiredParamError = {
 const findRequiredParamError = (
   errorParams: Record<string, unknown>,
 ): false | RequiredParamError => {
-  let requiredParamError: unknown = false;
-
   if (!errorParams.errors || !Array.isArray(errorParams.errors)) {
     return false;
   }
 
-  requiredParamError = errorParams.errors.find(
+  const requiredParamError = errorParams.errors.find(
     (error: unknown) =>
       isObject<Record<string, unknown>>(error) && error.keyword === 'required',
   );
 
+  // Check if the correct properties are present in the error object
   if (
     requiredParamError &&
     isObject<Record<string, unknown>>(requiredParamError) &&

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "reflect-metadata": "^0.1.13",
     "superstruct": "^1.0.3",
     "typanion": "^3.14.0",
-    "typescript": "^5.1.6",
+    "typescript": "5.1.6",
     "valibot": "^0.24.1",
     "vest": "^4.6.11",
     "vite": "^4.4.9",

--- a/package.json
+++ b/package.json
@@ -261,7 +261,7 @@
     "reflect-metadata": "^0.1.13",
     "superstruct": "^1.0.3",
     "typanion": "^3.14.0",
-    "typescript": "5.1.6",
+    "typescript": "^5.1.6",
     "valibot": "^0.24.1",
     "vest": "^4.6.11",
     "vite": "^4.4.9",


### PR DESCRIPTION
Resolves issue: [#615](https://github.com/react-hook-form/resolvers/issues/615)

Changes
- Add logic to infer instance path for properties which are required and which have custom error message
- Add tests for the above changes