### PR TITLE
isZodError: check if error.errors is actually an array

### DIFF
--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -3,7 +3,7 @@ import { z, ZodError } from 'zod';
 import { toNestErrors, validateFieldsNatively } from '@hookform/resolvers';
 import type { Resolver } from './types';
 
-const isZodError = (error: any): error is ZodError => error.errors != null;
+const isZodError = (error: any): error is ZodError => Array.isArray(error?.errors);
 
 const parseErrorSchema = (
   zodErrors: z.ZodIssue[],


### PR DESCRIPTION
`ZodError` type expects `errors` prop to be an array

```ts
export declare class ZodError<T = any> extends Error {
    issues: ZodIssue[];
    get errors(): ZodIssue[];
    constructor(issues: ZodIssue[]);
    format(): ZodFormattedError<T>;
    format<U>(mapper: (issue: ZodIssue) => U): ZodFormattedError<T, U>;
    static create: (issues: ZodIssue[]) => ZodError<any>;
    toString(): string;
    get message(): string;
    get isEmpty(): boolean;
    addIssue: (sub: ZodIssue) => void;
    addIssues: (subs?: ZodIssue[]) => void;
    flatten(): typeToFlattenedError<T>;
    flatten<U>(mapper?: (issue: ZodIssue) => U): typeToFlattenedError<T, U>;
    get formErrors(): typeToFlattenedError<T, string>;
}
```

And `parseErrorSchema` function expects an array:

https://github.com/react-hook-form/resolvers/blob/f7a4fd46af51a2a732c10ed652f5abfa532f4198/zod/src/zod.ts#L8-L11

Recently, we encountered an issue where the props can be undefined for some reason. I propose this PR to add a stricter check to prevent unexpected circumstances where the `error.errors` object is not an array.

Resolve #696 