### PR TITLE
chore: upgrade @effect/schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,13 +653,13 @@ const App = () => {
 
 A powerful TypeScript framework that provides a fully-fledged functional effect system with a rich standard library.
 
-[![npm](https://img.shields.io/bundlephobia/minzip/@effect/schema?style=for-the-badge)](https://bundlephobia.com/result?p=effect)
+[![npm](https://img.shields.io/bundlephobia/minzip/effect?style=for-the-badge)](https://bundlephobia.com/result?p=effect)
 
 ```typescript jsx
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { effectTsResolver } from '@hookform/resolvers/effect-ts';
-import { Schema } from '@effect/schema';
+import { Schema } from 'effect';
 
 const schema = Schema.Struct({
   username: Schema.String.pipe(

--- a/effect-ts/package.json
+++ b/effect-ts/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@hookform/resolvers": "^2.0.0",
-    "@effect/schema": "^0.66.14",
+    "@effect/schema": "^0.70.0",
     "effect": "^3.1.2",
     "react-hook-form": "^7.0.0"
   }

--- a/effect-ts/package.json
+++ b/effect-ts/package.json
@@ -12,8 +12,7 @@
   "license": "MIT",
   "peerDependencies": {
     "@hookform/resolvers": "^2.0.0",
-    "@effect/schema": "^0.70.0",
-    "effect": "^3.1.2",
+    "effect": "^3.10.0",
     "react-hook-form": "^7.0.0"
   }
 }

--- a/effect-ts/src/__tests__/Form-native-validation.tsx
+++ b/effect-ts/src/__tests__/Form-native-validation.tsx
@@ -1,6 +1,6 @@
-import { Schema } from '@effect/schema';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
+import { Schema } from 'effect';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { effectTsResolver } from '..';
@@ -10,10 +10,10 @@ const PASSWORD_REQUIRED_MESSAGE = 'password field is required';
 
 const schema = Schema.Struct({
   username: Schema.String.pipe(
-    Schema.nonEmpty({ message: () => USERNAME_REQUIRED_MESSAGE }),
+    Schema.nonEmptyString({ message: () => USERNAME_REQUIRED_MESSAGE }),
   ),
   password: Schema.String.pipe(
-    Schema.nonEmpty({ message: () => PASSWORD_REQUIRED_MESSAGE }),
+    Schema.nonEmptyString({ message: () => PASSWORD_REQUIRED_MESSAGE }),
   ),
 });
 

--- a/effect-ts/src/__tests__/Form.tsx
+++ b/effect-ts/src/__tests__/Form.tsx
@@ -1,6 +1,6 @@
-import { Schema } from '@effect/schema';
 import { render, screen } from '@testing-library/react';
 import user from '@testing-library/user-event';
+import { Schema } from 'effect';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import { effectTsResolver } from '..';
@@ -10,10 +10,10 @@ const PASSWORD_REQUIRED_MESSAGE = 'password field is required';
 
 const schema = Schema.Struct({
   username: Schema.String.pipe(
-    Schema.nonEmpty({ message: () => USERNAME_REQUIRED_MESSAGE }),
+    Schema.nonEmptyString({ message: () => USERNAME_REQUIRED_MESSAGE }),
   ),
   password: Schema.String.pipe(
-    Schema.nonEmpty({ message: () => PASSWORD_REQUIRED_MESSAGE }),
+    Schema.nonEmptyString({ message: () => PASSWORD_REQUIRED_MESSAGE }),
   ),
 });
 

--- a/effect-ts/src/__tests__/__fixtures__/data.ts
+++ b/effect-ts/src/__tests__/__fixtures__/data.ts
@@ -1,9 +1,9 @@
-import { Schema } from '@effect/schema';
+import { Schema } from 'effect';
 import { Field, InternalFieldName } from 'react-hook-form';
 
 export const schema = Schema.Struct({
   username: Schema.String.pipe(
-    Schema.nonEmpty({ message: () => 'A username is required' }),
+    Schema.nonEmptyString({ message: () => 'A username is required' }),
   ),
   password: Schema.String.pipe(
     Schema.pattern(new RegExp('.*[A-Z].*'), {

--- a/effect-ts/src/effect-ts.ts
+++ b/effect-ts/src/effect-ts.ts
@@ -1,7 +1,6 @@
-import { formatIssue } from '@effect/schema/ArrayFormatter';
-import { decodeUnknown } from '@effect/schema/ParseResult';
 import { toNestErrors, validateFieldsNatively } from '@hookform/resolvers';
 import * as Effect from 'effect/Effect';
+import { ArrayFormatter, decodeUnknown } from 'effect/ParseResult';
 import type { FieldErrors } from 'react-hook-form';
 import type { Resolver } from './types';
 
@@ -12,7 +11,9 @@ export const effectTsResolver: Resolver =
       schema,
       config,
     )(values).pipe(
-      Effect.catchAll((parseIssue) => Effect.flip(formatIssue(parseIssue))),
+      Effect.catchAll((parseIssue) =>
+        Effect.flip(ArrayFormatter.formatIssue(parseIssue)),
+      ),
       Effect.mapError((issues) => {
         const errors = issues.reduce((acc, current) => {
           const key = current.path.join('.');

--- a/effect-ts/src/types.ts
+++ b/effect-ts/src/types.ts
@@ -1,5 +1,5 @@
-import { Schema } from '@effect/schema';
-import { ParseOptions } from '@effect/schema/AST';
+import { Schema } from 'effect';
+import { ParseOptions } from 'effect/SchemaAST';
 import { FieldValues, ResolverOptions, ResolverResult } from 'react-hook-form';
 
 export type Resolver = <A extends FieldValues, I, TContext>(

--- a/package.json
+++ b/package.json
@@ -256,7 +256,7 @@
   },
   "homepage": "https://react-hook-form.com",
   "devDependencies": {
-    "@effect/schema": "^0.68.17",
+    "@effect/schema": "^0.70.0",
     "@sinclair/typebox": "^0.32.34",
     "@testing-library/dom": "^10.3.1",
     "@testing-library/jest-dom": "^6.4.6",

--- a/package.json
+++ b/package.json
@@ -256,7 +256,6 @@
   },
   "homepage": "https://react-hook-form.com",
   "devDependencies": {
-    "@effect/schema": "^0.70.0",
     "@sinclair/typebox": "^0.32.34",
     "@testing-library/dom": "^10.3.1",
     "@testing-library/jest-dom": "^6.4.6",
@@ -277,7 +276,7 @@
     "class-validator": "^0.14.1",
     "computed-types": "^1.11.2",
     "cross-env": "^7.0.3",
-    "effect": "^3.4.7",
+    "effect": "^3.10.0",
     "fluentvalidation-ts": "^3.2.0",
     "fp-ts": "^2.16.7",
     "io-ts": "^2.2.21",


### PR DESCRIPTION
`@effect/schema` was recently merged into the core `effect` package (indicating its API stability), so this PR drops the dependency on the old package and uses the core one, with a couple internal changes to align with the latest schema API.