### PR TITLE
fix: isNameInFieldArray with names option

### DIFF
--- a/src/__tests__/toNestErrors.ts
+++ b/src/__tests__/toNestErrors.ts
@@ -39,6 +39,35 @@ test('transforms flat object to nested object and shouldUseNativeValidation: tru
   ).toHaveBeenCalledWith(flatObject.name.message);
 });
 
+test('transforms flat object to nested object with names option', () => {
+  const result = toNestErrors(
+    {
+      username: {
+        type: 'custom',
+        message: 'error',
+      },
+    },
+    {
+      names: ['username', 'username.first'],
+      fields: {
+        username: {
+          name: 'username',
+          ref: { name: 'username' },
+        },
+      },
+      shouldUseNativeValidation: false,
+    },
+  );
+
+  expect(result).toEqual({
+    username: {
+      type: 'custom',
+      message: 'error',
+      ref: { name: 'username' },
+    },
+  });
+});
+
 test('transforms flat object to nested object with root error for field array', () => {
   const result = toNestErrors(
     {

--- a/src/toNestErrors.ts
+++ b/src/toNestErrors.ts
@@ -38,4 +38,4 @@ export const toNestErrors = <TFieldValues extends FieldValues>(
 const isNameInFieldArray = (
   names: InternalFieldName[],
   name: InternalFieldName,
-) => names.some((n) => n.startsWith(name + '.'));
+) => names.some((n) => n.match(`^${name}\\.\\d+`));


### PR DESCRIPTION
# Issue
- https://github.com/react-hook-form/resolvers/issues/627

# Details
Because of https://github.com/react-hook-form/resolvers/pull/621, nested object error becomes not consistent when a key of the object is used in `option.names`.

**To Reproduce**
1. go to [codesandbox](https://codesandbox.io/p/sandbox/x65hh6?layout=%257B%2522sidebarPanel%2522%253A%2522EXPLORER%2522%252C%2522rootPanelGroup%2522%253A%257B%2522direction%2522%253A%2522horizontal%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522id%2522%253A%2522ROOT_LAYOUT%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522UNKNOWN%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522cm0b3xoks00063b6mue46slnk%2522%252C%2522sizes%2522%253A%255B100%255D%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522EDITOR%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522EDITOR%2522%252C%2522id%2522%253A%2522cm0b3xoks00023b6m7js2xvio%2522%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522direction%2522%253A%2522horizontal%2522%252C%2522id%2522%253A%2522SHELLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522SHELLS%2522%252C%2522id%2522%253A%2522cm0b3xoks00033b6mmstu343b%2522%257D%255D%257D%255D%257D%252C%257B%2522type%2522%253A%2522PANEL_GROUP%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522direction%2522%253A%2522vertical%2522%252C%2522id%2522%253A%2522DEVTOOLS%2522%252C%2522panels%2522%253A%255B%257B%2522type%2522%253A%2522PANEL%2522%252C%2522contentType%2522%253A%2522DEVTOOLS%2522%252C%2522id%2522%253A%2522cm0b3xoks00053b6mdfc7brti%2522%257D%255D%257D%255D%252C%2522sizes%2522%253A%255B50%252C50%255D%257D%252C%2522tabbedPanels%2522%253A%257B%2522cm0b3xoks00023b6m7js2xvio%2522%253A%257B%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cm0b3xoks00013b6mb5lm115a%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252Findex.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%257D%252C%257B%2522id%2522%253A%2522cm0i6iny600023b6jugx6j61f%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522FILE%2522%252C%2522filepath%2522%253A%2522%252Fsrc%252FApp.tsx%2522%252C%2522state%2522%253A%2522IDLE%2522%252C%2522initialSelections%2522%253A%255B%257B%2522startLineNumber%2522%253A41%252C%2522startColumn%2522%253A33%252C%2522endLineNumber%2522%253A41%252C%2522endColumn%2522%253A33%257D%255D%257D%255D%252C%2522id%2522%253A%2522cm0b3xoks00023b6m7js2xvio%2522%252C%2522activeTabId%2522%253A%2522cm0i6iny600023b6jugx6j61f%2522%257D%252C%2522cm0b3xoks00053b6mdfc7brti%2522%253A%257B%2522id%2522%253A%2522cm0b3xoks00053b6mdfc7brti%2522%252C%2522activeTabId%2522%253A%2522cm0b4l4yx005l3b6m0szymcu6%2522%252C%2522tabs%2522%253A%255B%257B%2522id%2522%253A%2522cm0b3xoks00043b6mqzrwg2dn%2522%252C%2522mode%2522%253A%2522permanent%2522%252C%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%257D%252C%257B%2522type%2522%253A%2522UNASSIGNED_PORT%2522%252C%2522port%2522%253A0%252C%2522id%2522%253A%2522cm0b4l4yx005l3b6m0szymcu6%2522%252C%2522mode%2522%253A%2522permanent%2522%257D%255D%257D%252C%2522cm0b3xoks00033b6mmstu343b%2522%253A%257B%2522tabs%2522%253A%255B%255D%252C%2522id%2522%253A%2522cm0b3xoks00033b6mmstu343b%2522%257D%257D%252C%2522showDevtools%2522%253Atrue%252C%2522showShells%2522%253Afalse%252C%2522showSidebar%2522%253Atrue%252C%2522sidebarPanelSize%2522%253A15%257D)
2. type "A" and click submit button
3. you can see `error.name.root.message` because `"name"` is used in `deps`
4. type "B"
5. you can see `error.name.message`

**changes**
- fix logic of `isNameInFieldArray`
- add test for `toNestErrors` with names option