### PR TITLE
perf(ajv): reuse compiled schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,14 +465,14 @@ const schema = {
   additionalProperties: false,
 };
 
+const resolver = ajvResolver(schema);
+
 const App = () => {
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({
-    resolver: ajvResolver(schema),
-  });
+  } = useForm({ resolver });
 
   return (
     <form onSubmit={handleSubmit((data) => console.log(data))}>

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -45,28 +45,31 @@ const parseErrorSchema = (
   }, {});
 };
 
-export const ajvResolver: Resolver =
-  (schema, schemaOptions, resolverOptions = {}) =>
-  async (values, _, options) => {
-    const ajv = new Ajv(
-      Object.assign(
-        {},
-        {
-          allErrors: true,
-          validateSchema: true,
-        },
-        schemaOptions,
-      ),
-    );
+export const ajvResolver: Resolver = (
+  schema,
+  schemaOptions,
+  resolverOptions = {},
+) => {
+  const ajv = new Ajv(
+    Object.assign(
+      {},
+      {
+        allErrors: true,
+        validateSchema: true,
+      },
+      schemaOptions,
+    ),
+  );
 
-    ajvErrors(ajv);
+  ajvErrors(ajv);
 
-    const validate = ajv.compile(
-      Object.assign(
-        { $async: resolverOptions && resolverOptions.mode === 'async' },
-        schema,
-      ),
-    );
+  const modifiedSchema = Object.assign(
+    { $async: resolverOptions && resolverOptions.mode === 'async' },
+    schema,
+  );
+
+  return async (values, _, options) => {
+    const validate = ajv.compile(modifiedSchema);
 
     const valid = validate(values);
 
@@ -86,3 +89,4 @@ export const ajvResolver: Resolver =
           ),
         };
   };
+};


### PR DESCRIPTION
Moved initialization of Ajv, ajvErrors and the creation of the adjusted schema outside of the Resolver to allow the instance of Ajv to reuse the compiled schema on multiple invocations of the Resolver. Also adjusted the example usage in the README to show that the ajvResolver should only be called once for the schema.

This aligns with the recommended approach of compiling a schema only once as described in the docs under [Managing schemas](https://ajv.js.org/guide/managing-schemas.html).

Overall this should also significantly reduce the memory footprint since the instance of Ajv and the modified schema is reused.