### PR TITLE
fix: Valibot peer dependency to support dist-tags

### DIFF
--- a/valibot/package.json
+++ b/valibot/package.json
@@ -13,6 +13,6 @@
   "peerDependencies": {
     "@hookform/resolvers": "^2.0.0",
     "react-hook-form": "^7.0.0",
-    "valibot": "^1.0.0"
+    "valibot": "^1.0.0 || ^1.0.0-beta || ^1.0.0-rc"
   }
 }


### PR DESCRIPTION
Looks like the npm install broke with the upgrade to Valibot v1. This PR should fix that.