### PR TITLE
Use stable version for ArkType 2

### DIFF
--- a/arktype/package.json
+++ b/arktype/package.json
@@ -13,6 +13,6 @@
   "peerDependencies": {
     "react-hook-form": "^7.0.0",
     "@hookform/resolvers": "^2.0.0",
-    "arktype": "2.0.0-dev.14"
+    "arktype": "^2.0.0"
   }
 }


### PR DESCRIPTION
Version 2.0 was released: https://x.com/arktypeio/status/1880328086023217644