### PR TITLE
fix(validateFieldsNatively): handle undefined object when reading 'refs'

### DIFF
--- a/src/validateFieldsNatively.ts
+++ b/src/validateFieldsNatively.ts
@@ -29,7 +29,7 @@ export const validateFieldsNatively = <TFieldValues extends FieldValues>(
     const field = options.fields[fieldPath];
     if (field && field.ref && 'reportValidity' in field.ref) {
       setCustomValidity(field.ref, fieldPath, errors);
-    } else if (field.refs) {
+    } else if (field && field.refs) {
       field.refs.forEach((ref: HTMLInputElement) =>
         setCustomValidity(ref, fieldPath, errors),
       );


### PR DESCRIPTION
Added a missing check to ensure `field` is defined, similar to the existing check in the preceding `if` condition.

Fixes #692 

@bluebill1049 Review is welcome, but please don’t merge. Thank you!