### PR TITLE
docs: update resolver documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Install your preferred validation library alongside `@hookform/resolvers`.
 
 ## Links
 
-- [React-hook-form validation resolver documentation ](https://react-hook-form.com/api/useform/#resolver)
+- [React-hook-form validation resolver documentation ](https://react-hook-form.com/docs/useform#resolver)
 
 ### Supported resolvers
 


### PR DESCRIPTION
the provided link didn't go to related section of documentation