### PR TITLE
fix(standard-schema): Propertly handle object path segments 

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,6 +9,7 @@
       "devDependencies": {
         "@sinclair/typebox": "^0.34.15",
         "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.2.0",
@@ -411,6 +412,8 @@
     "@sinclair/typebox": ["@sinclair/typebox@0.34.16", "", {}, "sha512-rIljj8VPYAfn26ANY+5pCNVBPiv6hSufuKGe46y65cJZpvx8vHvPXlU0Q/Le4OGtlNaL8Jg2FuhtvQX18lSIqA=="],
 
     "@standard-schema/spec": ["@standard-schema/spec@1.0.0", "", {}, "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA=="],
+
+    "@standard-schema/utils": ["@standard-schema/utils@0.3.0", "", {}, "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g=="],
 
     "@surma/rollup-plugin-off-main-thread": ["@surma/rollup-plugin-off-main-thread@2.2.3", "", { "dependencies": { "ejs": "^3.1.6", "json5": "^2.2.0", "magic-string": "^0.25.0", "string.prototype.matchall": "^4.0.6" } }, "sha512-lR8q/9W7hZpMWweNiAKU7NQerBnzQQLvi8qnTDU/fxItPhtZVMbPV3lbCwjhIlNBe9Bbr5V+KHshvWmVSG9cxQ=="],
 

--- a/package.json
+++ b/package.json
@@ -269,6 +269,7 @@
   "devDependencies": {
     "@sinclair/typebox": "^0.34.15",
     "@standard-schema/spec": "^1.0.0",
+    "@standard-schema/utils": "^0.3.0",
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.2.0",

--- a/standard-schema/package.json
+++ b/standard-schema/package.json
@@ -13,6 +13,7 @@
   "peerDependencies": {
     "react-hook-form": "^7.0.0",
     "@standard-schema/spec": "^1.0.0",
+    "@standard-schema/utils": "^0.3.0",
     "@hookform/resolvers": "^2.0.0"
   }
 }

--- a/standard-schema/src/__tests__/__fixtures__/data.ts
+++ b/standard-schema/src/__tests__/__fixtures__/data.ts
@@ -1,3 +1,4 @@
+import { StandardSchemaV1 } from '@standard-schema/spec';
 import { Field, InternalFieldName } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -84,5 +85,27 @@ export const fields: Record<InternalFieldName, Field['_f']> = {
   birthday: {
     ref: { name: 'birthday' },
     name: 'birthday',
+  },
+};
+
+export const customSchema: StandardSchemaV1<
+  StandardSchemaV1.InferInput<typeof schema>,
+  StandardSchemaV1.InferOutput<typeof schema>
+> = {
+  '~standard': {
+    version: 1,
+    vendor: 'custom',
+    validate: () => ({
+      issues: [
+        {
+          path: [{ key: 'username' }],
+          message: 'Custom error',
+        },
+        {
+          path: [{ key: 'like' }, { key: 0 }, { key: 'id' }],
+          message: 'Custom error',
+        },
+      ],
+    }),
   },
 };

--- a/standard-schema/src/__tests__/__snapshots__/standard-schema.ts.snap
+++ b/standard-schema/src/__tests__/__snapshots__/standard-schema.ts.snap
@@ -1,5 +1,29 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`standardSchemaResolver > should correctly handle path segments that are objects 1`] = `
+{
+  "errors": {
+    "like": [
+      {
+        "id": {
+          "message": "Custom error",
+          "ref": undefined,
+          "type": "",
+        },
+      },
+    ],
+    "username": {
+      "message": "Custom error",
+      "ref": {
+        "name": "username",
+      },
+      "type": "",
+    },
+  },
+  "values": {},
+}
+`;
+
 exports[`standardSchemaResolver > should return a single error from standardSchemaResolver when validation fails 1`] = `
 {
   "errors": {

--- a/standard-schema/src/__tests__/standard-schema.ts
+++ b/standard-schema/src/__tests__/standard-schema.ts
@@ -1,5 +1,11 @@
 import { standardSchemaResolver } from '..';
-import { fields, invalidData, schema, validData } from './__fixtures__/data';
+import {
+  customSchema,
+  fields,
+  invalidData,
+  schema,
+  validData,
+} from './__fixtures__/data';
 
 const shouldUseNativeValidation = false;
 
@@ -51,6 +57,18 @@ describe('standardSchemaResolver', () => {
     });
 
     expect(validateSpy).toHaveBeenCalledTimes(1);
+    expect(result).toMatchSnapshot();
+  });
+  it('should correctly handle path segments that are objects', async () => {
+    const result = await standardSchemaResolver(customSchema)(
+      validData,
+      undefined,
+      {
+        fields,
+        shouldUseNativeValidation,
+      },
+    );
+
     expect(result).toMatchSnapshot();
   });
 });

--- a/standard-schema/src/standard-schema.ts
+++ b/standard-schema/src/standard-schema.ts
@@ -1,5 +1,6 @@
 import { toNestErrors, validateFieldsNatively } from '@hookform/resolvers';
 import { StandardSchemaV1 } from '@standard-schema/spec';
+import { getDotPath } from '@standard-schema/utils';
 import { FieldError, FieldValues, Resolver } from 'react-hook-form';
 
 function parseIssues(
@@ -10,7 +11,7 @@ function parseIssues(
 
   for (let i = 0; i < issues.length; i++) {
     const error = issues[i];
-    const path = error.path?.join('.');
+    const path = getDotPath(error);
 
     if (path) {
       if (!errors[path]) {

--- a/standard-schema/src/standard-schema.ts
+++ b/standard-schema/src/standard-schema.ts
@@ -52,15 +52,14 @@ function parseIssues(
  * ```
  */
 export function standardSchemaResolver<
-  TFieldValues extends FieldValues,
-  Schema extends StandardSchemaV1<TFieldValues, any>,
+  Schema extends StandardSchemaV1<FieldValues>,
 >(
   schema: Schema,
   resolverOptions: {
     raw?: boolean;
   } = {},
-): Resolver<NonNullable<(typeof schema)['~standard']['types']>['output']> {
-  return async (values: TFieldValues, _, options) => {
+): Resolver<StandardSchemaV1.InferOutput<Schema>> {
+  return async (values, _, options) => {
     let result = schema['~standard'].validate(values);
     if (result instanceof Promise) {
       result = await result;


### PR DESCRIPTION
In StandardSchema issues, path segments can either be keys or an object with a `.key` value.
Current handling just calls `path.join('.')`, which would result in `"object Object"` if any path segments are objects.

The Standard Schema team have `@standard-schema/utils` which includes a `getDotPath` that handles segments correctly, so I've used that.