### PR TITLE
fix(zod): update return type in zodResolver to use z.input instead of…

### DIFF
--- a/zod/src/__tests__/Form.tsx
+++ b/zod/src/__tests__/Form.tsx
@@ -10,17 +10,22 @@ const schema = z.object({
   password: z.string().nonempty({ message: 'password field is required' }),
 });
 
-type FormData = z.infer<typeof schema> & { unusedProperty: string };
+type SchemaInput = z.input<typeof schema>;
+type FormData = z.output<typeof schema> & { unusedProperty: string };
 
 function TestComponent({
   onSubmit,
-}: { onSubmit: (data: z.infer<typeof schema>) => void }) {
+}: { onSubmit: (data: z.output<typeof schema>) => void }) {
   const {
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm({
+  } = useForm<SchemaInput, unknown, FormData>({
     resolver: zodResolver(schema), // Useful to check TypeScript regressions
+    defaultValues: {
+      username: '',
+      password: '',
+    },
   });
 
   return (
@@ -58,7 +63,7 @@ export function TestComponentManualType({
     register,
     handleSubmit,
     formState: { errors },
-  } = useForm<z.infer<typeof schema>, undefined, FormData>({
+  } = useForm<SchemaInput, undefined, FormData>({
     resolver: zodResolver(schema), // Useful to check TypeScript regressions
   });
 

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -68,7 +68,7 @@ function parseErrorSchema(
  * @param {Object} [resolverOptions] - Optional resolver-specific configuration
  * @param {('async'|'sync')} [resolverOptions.mode='async'] - Validation mode. Use 'sync' for synchronous validation
  * @param {boolean} [resolverOptions.raw=false] - If true, returns the raw form values instead of the parsed data
- * @returns {Resolver<z.infer<typeof schema>>} A resolver function compatible with react-hook-form
+ * @returns {Resolver<z.input<typeof schema>>} A resolver function compatible with react-hook-form
  * @throws {Error} Throws if validation fails with a non-Zod error
  * @example
  * const schema = z.object({
@@ -87,7 +87,7 @@ export function zodResolver<TFieldValues extends FieldValues>(
     mode?: 'async' | 'sync';
     raw?: boolean;
   } = {},
-): Resolver<z.infer<typeof schema>> {
+): Resolver<z.input<typeof schema>> {
   return async (values, _, options) => {
     try {
       const data = await schema[


### PR DESCRIPTION
Resolves #743 

For the function zodResolver to return a type compatible with react-hook-form, it must return `Resolver<z.input<typeof schema>>` instead of `Resolver<z.infer<typeof schema>>`.