### PR TITLE
add prebuild script to collect peerdeps

### DIFF
--- a/config/collect-peerdeps.js
+++ b/config/collect-peerdeps.js
@@ -1,0 +1,25 @@
+import fs from 'node:fs/promises';
+import { join } from 'node:path';
+
+const packageJsons = await Promise.all(
+  (await fs.readdir('./')).map((p) =>
+    fs
+      .readFile(join(p, 'package.json'))
+      .then(JSON.parse)
+      .catch((e) => {}),
+  ),
+);
+
+const peerDependencies = Object.fromEntries(
+  packageJsons.flatMap((pj) => Object.entries(pj?.peerDependencies ?? {})),
+);
+
+const packageJson = {
+  ...JSON.parse(await fs.readFile('package.json')),
+  peerDependencies,
+};
+
+await fs.writeFile(
+  'package.json',
+  `${JSON.stringify(packageJson, null, 2)}\n`, // newline at EOF
+);

--- a/config/collect-peerdeps.js
+++ b/config/collect-peerdeps.js
@@ -14,9 +14,17 @@ const peerDependencies = Object.fromEntries(
   packageJsons.flatMap((pj) => Object.entries(pj?.peerDependencies ?? {})),
 );
 
+const peerDependenciesMeta = Object.fromEntries(
+  Object.entries(peerDependencies).map(([pName]) => [
+    pName,
+    { optional: true },
+  ]),
+);
+
 const packageJson = {
   ...JSON.parse(await fs.readFile('package.json')),
   peerDependencies,
+  peerDependenciesMeta,
 };
 
 await fs.writeFile(

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -22,3 +22,7 @@ pre-commit:
     typescript:
       glob: '*.{ts,tsx}'
       run: bun tsc --noEmit
+    collect-peerdeps:
+      glob: '**/package.json'
+      run: node ./config/collect-peerdeps.js
+      stage_fixed: true

--- a/package.json
+++ b/package.json
@@ -221,6 +221,7 @@
     "build:vine": "microbundle --cwd vine --globals @hookform/resolvers=hookformResolvers,react-hook-form=ReactHookForm,@vinejs/vine=vine",
     "build:fluentvalidation-ts": "microbundle --cwd fluentvalidation-ts --globals @hookform/resolvers=hookformResolvers,react-hook-form=ReactHookForm",
     "build:standard-schema": "microbundle --cwd standard-schema --globals @hookform/resolvers=hookformResolvers,react-hook-form=ReactHookForm,@standard-schema/spec=standardSchema",
+    "prebuild": "node ./config/collect-peerdeps.js",
     "postbuild": "node ./config/node-13-exports.js && check-export-map",
     "lint": "bunx @biomejs/biome check --write --vcs-use-ignore-file=true .",
     "lint:types": "tsc",
@@ -317,7 +318,27 @@
     "zod": "^3.24.2"
   },
   "peerDependencies": {
-    "react-hook-form": "^7.55.0"
+    "react-hook-form": "^7.55.0",
+    "@hookform/resolvers": "^2.0.0",
+    "ajv": "^8.12.0",
+    "ajv-errors": "^3.0.0",
+    "arktype": "^2.0.0",
+    "class-transformer": "^0.4.0",
+    "class-validator": "^0.12.0",
+    "effect": "^3.10.3",
+    "fluentvalidation-ts": "^3.0.0",
+    "io-ts": "^2.0.0",
+    "fp-ts": "^2.7.0",
+    "nope-validator": "^0.12.0",
+    "@standard-schema/spec": "^1.0.0",
+    "@standard-schema/utils": "^0.3.0",
+    "superstruct": ">=0.12.0",
+    "typanion": "^3.3.2",
+    "@sinclair/typebox": "^0.25.24",
+    "@typeschema/main": "^0.13.7",
+    "valibot": "^1.0.0 || ^1.0.0-beta.4 || ^1.0.0-rc",
+    "vest": ">=3.0.0",
+    "@vinejs/vine": "^2.0.0"
   },
   "dependencies": {
     "@standard-schema/utils": "^0.3.0"

--- a/package.json
+++ b/package.json
@@ -340,7 +340,69 @@
     "vest": ">=3.0.0",
     "@vinejs/vine": "^2.0.0"
   },
-  "dependencies": {
-    "@standard-schema/utils": "^0.3.0"
+  "peerDependenciesMeta": {
+    "react-hook-form": {
+      "optional": true
+    },
+    "@hookform/resolvers": {
+      "optional": true
+    },
+    "ajv": {
+      "optional": true
+    },
+    "ajv-errors": {
+      "optional": true
+    },
+    "arktype": {
+      "optional": true
+    },
+    "class-transformer": {
+      "optional": true
+    },
+    "class-validator": {
+      "optional": true
+    },
+    "effect": {
+      "optional": true
+    },
+    "fluentvalidation-ts": {
+      "optional": true
+    },
+    "io-ts": {
+      "optional": true
+    },
+    "fp-ts": {
+      "optional": true
+    },
+    "nope-validator": {
+      "optional": true
+    },
+    "@standard-schema/spec": {
+      "optional": true
+    },
+    "@standard-schema/utils": {
+      "optional": true
+    },
+    "superstruct": {
+      "optional": true
+    },
+    "typanion": {
+      "optional": true
+    },
+    "@sinclair/typebox": {
+      "optional": true
+    },
+    "@typeschema/main": {
+      "optional": true
+    },
+    "valibot": {
+      "optional": true
+    },
+    "vest": {
+      "optional": true
+    },
+    "@vinejs/vine": {
+      "optional": true
+    }
   }
 }


### PR DESCRIPTION
This adds a simple js script that is run before builds and commits that collects all peerDependencies from all subfolders together and inserts them into the root package.json. This closes #762