### PR TITLE
feat: add an errors getter compatible with zod v4

### DIFF
--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -10,6 +10,17 @@ import {
 } from 'react-hook-form';
 import { ZodError, z } from 'zod';
 
+// Add an errors getter compatible with zod v4
+if(!ZodError.prototype.errors){
+  Object.defineProperty(ZodError.prototype, "errors", {
+    get() {
+      return this.issues;
+    },
+    enumerable: true,
+    configurable: true,
+  });
+}
+
 const isZodError = (error: any): error is ZodError =>
   Array.isArray(error?.errors);
 


### PR DESCRIPTION
#768 

```
Object.defineProperty(ZodError.prototype, "errors", {
    get() {
        return this.issues;
    },
    enumerable: true,
    configurable: true,
});

const form = useForm<{ [x: string]: never }>({
    resolver: zodResolver(FormSchema),
    defaultValues: data as { [x: string]: never },
});
```