### PR TITLE
feat: zod v4 support #768

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
       "name": "@hookform/resolvers",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0",
+        "zod-v4": "npm:zod@^3.25.0",
       },
       "devDependencies": {
         "@sinclair/typebox": "^0.34.30",
@@ -1445,6 +1446,8 @@
     "yup": ["yup@1.6.1", "", { "dependencies": { "property-expr": "^2.0.5", "tiny-case": "^1.0.3", "toposort": "^2.0.2", "type-fest": "^2.19.0" } }, "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA=="],
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
+
+    "zod-v4": ["zod@3.25.42", "", {}, "sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ=="],
 
     "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -55,7 +55,7 @@
         "vite-tsconfig-paths": "^5.1.4",
         "vitest": "^3.0.9",
         "yup": "^1.6.1",
-        "zod": "^3.24.2",
+        "zod": "3.24.4",
       },
       "peerDependencies": {
         "react-hook-form": "^7.55.0",
@@ -1445,7 +1445,7 @@
 
     "yup": ["yup@1.6.1", "", { "dependencies": { "property-expr": "^2.0.5", "tiny-case": "^1.0.3", "toposort": "^2.0.2", "type-fest": "^2.19.0" } }, "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA=="],
 
-    "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
+    "zod": ["zod@3.24.4", "", {}, "sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg=="],
 
     "zod-v4": ["zod@3.25.42", "", {}, "sha512-PcALTLskaucbeHc41tU/xfjfhcz8z0GdhhDcSgrCTmSazUuqnYqiXO63M0QUBVwpBlsLsNVn5qHSC5Dw3KZvaQ=="],
 

--- a/package.json
+++ b/package.json
@@ -320,6 +320,7 @@
     "react-hook-form": "^7.55.0"
   },
   "dependencies": {
-    "@standard-schema/utils": "^0.3.0"
+    "@standard-schema/utils": "^0.3.0",
+    "zod-v4": "npm:zod@^3.25.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.9",
     "yup": "^1.6.1",
-    "zod": "^3.24.2"
+    "zod": "3.24.4"
   },
   "peerDependencies": {
     "react-hook-form": "^7.55.0"

--- a/package.json
+++ b/package.json
@@ -314,13 +314,13 @@
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "^3.0.9",
     "yup": "^1.6.1",
-    "zod": "3.24.4"
+    "zod": "3.24.4",
+    "zod-v4": "npm:zod@^3.25.0"
   },
   "peerDependencies": {
     "react-hook-form": "^7.55.0"
   },
   "dependencies": {
-    "@standard-schema/utils": "^0.3.0",
-    "zod-v4": "npm:zod@^3.25.0"
+    "@standard-schema/utils": "^0.3.0"
   }
 }

--- a/typebox/src/__tests__/typebox.ts
+++ b/typebox/src/__tests__/typebox.ts
@@ -1,8 +1,8 @@
+import { Type } from '@sinclair/typebox';
+import { TypeCompiler } from '@sinclair/typebox/compiler';
 import { Resolver, SubmitHandler, useForm } from 'react-hook-form';
 import { typeboxResolver } from '..';
 import { fields, invalidData, schema, validData } from './__fixtures__/data';
-import { Type } from '@sinclair/typebox';
-import { TypeCompiler } from '@sinclair/typebox/compiler';
 
 const shouldUseNativeValidation = false;
 

--- a/zod/src/index.ts
+++ b/zod/src/index.ts
@@ -1,1 +1,2 @@
-export * from './zod';
+export { zodResolver } from './zod';
+export { zodResolver as zodResolverV4 } from './zodv4';

--- a/zod/src/zodv4.ts
+++ b/zod/src/zodv4.ts
@@ -1,0 +1,143 @@
+import { toNestErrors, validateFieldsNatively } from '@hookform/resolvers';
+import {
+  FieldError,
+  FieldErrors,
+  FieldValues,
+  Resolver,
+  ResolverError,
+  ResolverSuccess,
+  appendErrors,
+} from 'react-hook-form';
+import { ZodError, z } from 'zod-v4/v4';
+
+function parseErrorSchema(
+  zodErrors: z.core.$ZodIssue[],
+  validateAllFieldCriteria: boolean,
+) {
+  const errors: Record<string, FieldError> = {};
+  for (; zodErrors.length; ) {
+    const error = zodErrors[0];
+    const { code, message, path } = error;
+    const _path = path.join('.');
+
+    if (!errors[_path]) {
+      if (error.code === 'invalid_union') {
+        const unionError = error.errors[0][0];
+
+        errors[_path] = {
+          message: unionError.message,
+          type: unionError.code,
+        };
+      } else {
+        errors[_path] = { message, type: code };
+      }
+    }
+
+    if (error.code === 'invalid_union') {
+      error.errors.forEach((unionError: any[]) =>
+        unionError.forEach((e) =>
+          zodErrors.push({
+            ...e,
+            path: [...path, ...e.path],
+          }),
+        ),
+      );
+    }
+
+    if (validateAllFieldCriteria) {
+      const types = errors[_path].types;
+      const messages = types && types[error.code];
+
+      errors[_path] = appendErrors(
+        _path,
+        validateAllFieldCriteria,
+        errors,
+        code,
+        messages
+          ? ([] as string[]).concat(messages as string[], error.message)
+          : error.message,
+      ) as FieldError;
+    }
+
+    zodErrors.shift();
+  }
+
+  return errors;
+}
+
+export function zodResolver<Input extends FieldValues, Context, Output>(
+  schema: z.ZodSchema<Output, Input>,
+  schemaOptions?: Partial<z.core.ParseContext<z.core.$ZodIssue>>,
+  resolverOptions?: {
+    mode?: 'async' | 'sync';
+    raw?: false;
+  },
+): Resolver<Input, Context, Output>;
+
+export function zodResolver<Input extends FieldValues, Context, Output>(
+  schema: z.ZodSchema<Output, Input>,
+  schemaOptions: Partial<z.core.ParseContext<z.core.$ZodIssue>> | undefined,
+  resolverOptions: {
+    mode?: 'async' | 'sync';
+    raw: true;
+  },
+): Resolver<Input, Context, Input>;
+
+/**
+ * Creates a resolver function for react-hook-form that validates form data using a Zod schema
+ * @param {z.ZodSchema<Input>} schema - The Zod schema used to validate the form data
+ * @param {Partial<z.ParseParams>} [schemaOptions] - Optional configuration options for Zod parsing
+ * @param {Object} [resolverOptions] - Optional resolver-specific configuration
+ * @param {('async'|'sync')} [resolverOptions.mode='async'] - Validation mode. Use 'sync' for synchronous validation
+ * @param {boolean} [resolverOptions.raw=false] - If true, returns the raw form values instead of the parsed data
+ * @returns {Resolver<z.output<typeof schema>>} A resolver function compatible with react-hook-form
+ * @throws {Error} Throws if validation fails with a non-Zod error
+ * @example
+ * const schema = z.object({
+ *   name: z.string().min(2),
+ *   age: z.number().min(18)
+ * });
+ *
+ * useForm({
+ *   resolver: zodResolver(schema)
+ * });
+ */
+export function zodResolver<Input extends FieldValues, Context, Output>(
+  schema: z.ZodSchema<Output, Input>,
+  schemaOptions?: Partial<z.core.ParseContext<z.core.$ZodIssue>>,
+  resolverOptions: {
+    mode?: 'async' | 'sync';
+    raw?: boolean;
+  } = {},
+): Resolver<Input, Context, Output | Input> {
+  return async (values: Input, _, options) => {
+    try {
+      const data = await schema[
+        resolverOptions.mode === 'sync' ? 'parse' : 'parseAsync'
+      ](values, schemaOptions);
+
+      options.shouldUseNativeValidation && validateFieldsNatively({}, options);
+
+      return {
+        errors: {} as FieldErrors,
+        values: resolverOptions.raw ? Object.assign({}, values) : data,
+      } satisfies ResolverSuccess<Output | Input>;
+    } catch (error) {
+      if (error instanceof ZodError) {
+        return {
+          values: {},
+          errors: toNestErrors(
+            parseErrorSchema(
+              (error as { issues: z.core.$ZodIssue[] }).issues,
+              !options.shouldUseNativeValidation &&
+                options.criteriaMode === 'all',
+            ),
+            options,
+          ),
+        } satisfies ResolverError<Input>;
+      }
+
+      throw error;
+    }
+  };
+}


### PR DESCRIPTION
## Support for Zod v4 with `zodResolverV4`

This PR adds support for the new version of Zod (v4) by introducing a new resolver: `zodResolverV4`. This allows users to work with schemas written using the latest version of Zod while maintaining compatibility with older implementations.

To ensure backward compatibility, the original `zodResolver` has **not** been removed or modified.

Due to issues related to tests in `typeschema.ts`, I’ve temporarily installed **two separate versions of Zod** (`zod` and `zod-v4`) to avoid breaking existing functionality. Ideally, in the future, it would be great to update those parts to also use the latest version of Zod.

### Usage

Using the new resolver is simple. You just need to import and use `zodResolverV4` like so:

```ts
const { control, handleSubmit, formState: { errors } } = useForm<User>({
  resolver: zodResolverV4(UserSchema),
  defaultValues: {
    name: '',
    device: {
      platform: 'ios',
      versions: []
    }
  }
});

```
Big thanks to @hukpo for mentioning this solution in [Issue #768](https://github.com/react-hook-form/resolvers/issues/768) 🙌