### PR TITLE
fix: discriminated union for zod

### DIFF
--- a/zod/src/__tests__/__fixtures__/data-v4-mini.ts
+++ b/zod/src/__tests__/__fixtures__/data-v4-mini.ts
@@ -43,6 +43,15 @@ export const schema = z
           message: 'Invalid date',
         }),
       ),
+    auth: z.discriminatedUnion('type', [
+      z.object({
+        type: z.literal('registered'),
+        passwordHash: z.string(),
+      }),
+      z.object({
+        type: z.literal('guest'),
+      }),
+    ]),
   })
   .check(
     z.refine((obj) => obj.password === obj.repeatPassword, {
@@ -68,6 +77,10 @@ export const validData = {
     },
   ],
   dateStr: '2020-01-01',
+  auth: {
+    type: 'registered',
+    passwordHash: 'hash',
+  },
 } satisfies z.input<typeof schema>;
 
 export const invalidData = {
@@ -76,6 +89,7 @@ export const invalidData = {
   birthYear: 'birthYear',
   like: [{ id: 'z' }],
   url: 'abc',
+  auth: { type: 'invalid' },
 } as unknown as z.input<typeof schema>;
 
 export const fields: Record<InternalFieldName, Field['_f']> = {

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -91,7 +91,7 @@ function parseZod4Issues(
     const _path = path.join('.');
 
     if (!errors[_path]) {
-      if (error.code === 'invalid_union') {
+      if (error.code === 'invalid_union' && error.errors.length > 0) {
         const unionError = error.errors[0][0];
 
         errors[_path] = {


### PR DESCRIPTION
# Context
When trying out the new Zod v4 mini I noticed that discriminated unions aren't supported.

# Changes
- Adding discriminated unions to the tests
- Using the current error on invalid union if the errors array is empty