### PR TITLE
fix: zod v4 peer deps

### DIFF
--- a/zod/package.json
+++ b/zod/package.json
@@ -13,6 +13,6 @@
   "peerDependencies": {
     "react-hook-form": "^7.55.0",
     "@hookform/resolvers": "^2.0.0",
-    "zod": "^3.25.0"
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
As explained in the "Library authors" part of the release of Zod v4, we can support easily Zod v4 without any code changes except updating the peer dependency version range (as the work was already done in #777).

Ref: https://github.com/colinhacks/zod/releases/tag/v4.0.1