### PR TITLE
fix(zod): fix output type for Zod 4 resolver

### DIFF
--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -215,7 +215,7 @@ export function zodResolver<
   schema: z4.$ZodType<Output, Input>,
   schemaOptions: Zod4ParseParams | undefined, // already partial
   resolverOptions: RawResolverOptions,
-): Resolver<z4.input<T>, Context, z4.input<T>>;
+): Resolver<z4.input<T>, Context, z4.output<T>>;
 /**
  * Creates a resolver function for react-hook-form that validates form data using a Zod schema
  * @param {z3.ZodSchema<Input>} schema - The Zod schema used to validate the form data


### PR DESCRIPTION
I wasn't able to run the tests sadly, as for some reason vitest didn't find any files.

I think this was a typo introduced in https://github.com/react-hook-form/resolvers/pull/777
