### PR TITLE
fix(zod): fix output type for Zod 4 resolver when raw option is enabled(#801)

### DIFF
--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -215,7 +215,7 @@ export function zodResolver<
   schema: z4.$ZodType<Output, Input>,
   schemaOptions: Zod4ParseParams | undefined, // already partial
   resolverOptions: RawResolverOptions,
-): Resolver<z4.input<T>, Context, z4.output<T>>;
+): Resolver<z4.input<T>, Context, z4.input<T>>;
 /**
  * Creates a resolver function for react-hook-form that validates form data using a Zod schema
  * @param {z3.ZodSchema<Input>} schema - The Zod schema used to validate the form data


### PR DESCRIPTION
This reverts commit bc09647a5eec21d07097a8ccf89fb52ebf50a1ec (PR #801).

---

I think #801 fix was not a typo.
When raw option is enabled, `TTransformedValues` should be `z.input`, not `z.output`.

```typescript
function zodResolver<
  Input extends FieldValues,
  Context,
  Output,
  T extends z4.$ZodType<Output, Input> = z4.$ZodType<Output, Input>,
>(
  schema: z4.$ZodType<Output, Input>,
  schemaOptions: Zod4ParseParams | undefined, // already partial
  resolverOptions: RawResolverOptions,
): Resolver<z4.input<T>, Context, z4.output<T>>;
```

```typescript
export type Resolver<TFieldValues extends FieldValues = FieldValues, TContext = any, TTransformedValues = TFieldValues> = (values: TFieldValues, context: TContext | undefined, options: ResolverOptions<TFieldValues>) => Promise<ResolverResult<TFieldValues, TTransformedValues>> | ResolverResult<TFieldValues, TTransformedValues>;
```


It breaks my project's type, when raw option is enabled.

TMI) For Zod v3, we can see `TTransformedValues` is correctly assigned when raw option is enabled as below.
```typescript
export function zodResolver<Input extends FieldValues, Context, Output>(
  schema: Zod3Type<Output, Input>,
  schemaOptions: Zod3ParseParams | undefined,
  resolverOptions: RawResolverOptions,
): Resolver<Input, Context, Input>;
```

Please tell me if i'm wrong!
Thank you for reading my purpose!