### PR TITLE
Fix (zod) : error paths in complex unions #787

### DIFF
--- a/valibot/src/valibot.ts
+++ b/valibot/src/valibot.ts
@@ -129,9 +129,7 @@ export function valibotResolver<Input extends FieldValues, Context, Output>(
 
     // Otherwise, return resolver result with values
     return {
-      values: resolverOptions.raw
-        ? Object.assign({}, values)
-        : (result.output as FieldValues),
+      values: resolverOptions.raw ? Object.assign({}, values) : result.output,
       errors: {},
     };
   };

--- a/vine/src/vine.ts
+++ b/vine/src/vine.ts
@@ -6,7 +6,6 @@ import {
 } from '@vinejs/vine/build/src/types';
 import {
   FieldError,
-  FieldErrors,
   FieldValues,
   Resolver,
   appendErrors,
@@ -94,7 +93,7 @@ export function vineResolver<Input extends FieldValues, Context, Output>(
       options.shouldUseNativeValidation && validateFieldsNatively({}, options);
 
       return {
-        errors: {} as FieldErrors,
+        errors: {},
         values: resolverOptions.raw ? Object.assign({}, values) : data,
       };
     } catch (error: any) {

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -105,7 +105,9 @@ function parseZod4Issues(
 
     if (error.code === 'invalid_union') {
       error.errors.forEach((unionError) =>
-        unionError.forEach((e) => zodErrors.push(e)),
+        unionError.forEach((e) =>
+          zodErrors.push({ ...e, path: [...error.path, ...e.path] }),
+        ),
       );
     }
 

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -256,7 +256,7 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
           validateFieldsNatively({}, options);
 
         return {
-          errors: {} as FieldErrors<Input>,
+          errors: {} as FieldErrors,
           values: resolverOptions.raw ? Object.assign({}, values) : data,
         } satisfies ResolverSuccess<Output | Input>;
       } catch (error) {
@@ -290,7 +290,7 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
           validateFieldsNatively({}, options);
 
         return {
-          errors: {} as FieldErrors<Input>,
+          errors: {} as FieldErrors,
           values: resolverOptions.raw ? Object.assign({}, values) : data,
         } satisfies ResolverSuccess<Output | Input>;
       } catch (error) {

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -256,7 +256,7 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
           validateFieldsNatively({}, options);
 
         return {
-          errors: {} as FieldErrors,
+          errors: {} as FieldErrors<Input>,
           values: resolverOptions.raw ? Object.assign({}, values) : data,
         } satisfies ResolverSuccess<Output | Input>;
       } catch (error) {
@@ -290,7 +290,7 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
           validateFieldsNatively({}, options);
 
         return {
-          errors: {} as FieldErrors,
+          errors: {} as FieldErrors<Input>,
           values: resolverOptions.raw ? Object.assign({}, values) : data,
         } satisfies ResolverSuccess<Output | Input>;
       } catch (error) {

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -1,7 +1,6 @@
 import { toNestErrors, validateFieldsNatively } from '@hookform/resolvers';
 import {
   FieldError,
-  FieldErrors,
   FieldValues,
   Resolver,
   ResolverError,
@@ -256,7 +255,7 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
           validateFieldsNatively({}, options);
 
         return {
-          errors: {} as FieldErrors,
+          errors: {},
           values: resolverOptions.raw ? Object.assign({}, values) : data,
         } satisfies ResolverSuccess<Output | Input>;
       } catch (error) {
@@ -290,7 +289,7 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
           validateFieldsNatively({}, options);
 
         return {
-          errors: {} as FieldErrors,
+          errors: {},
           values: resolverOptions.raw ? Object.assign({}, values) : data,
         } satisfies ResolverSuccess<Output | Input>;
       } catch (error) {


### PR DESCRIPTION
Fixes #787 

Solution proposed by https://github.com/Tekpakma in the issue works well. Error paths are now properly returned for unions in the zod resolver.

Also fixes type errors, there was unnecessary type assertions for errors when success is returned. (See previous commits failed builds)

Thanks for your consideration :) 