### PR TITLE
fix: fix nesting issue due to the errors order

### DIFF
--- a/src/__tests__/__snapshots__/toNestErrors.ts.snap
+++ b/src/__tests__/__snapshots__/toNestErrors.ts.snap
@@ -3,6 +3,11 @@
 exports[`transforms flat object to nested object 1`] = `
 {
   "name": {
+    "firstName": {
+      "message": "third message",
+      "ref": undefined,
+      "type": "rd",
+    },
     "message": "first message",
     "ref": {
       "reportValidity": [MockFunction spy],
@@ -25,6 +30,11 @@ exports[`transforms flat object to nested object 1`] = `
 exports[`transforms flat object to nested object and shouldUseNativeValidation: true 1`] = `
 {
   "name": {
+    "firstName": {
+      "message": "third message",
+      "ref": undefined,
+      "type": "rd",
+    },
     "message": "first message",
     "ref": {
       "reportValidity": [MockFunction spy] {

--- a/src/__tests__/toNestErrors.ts
+++ b/src/__tests__/toNestErrors.ts
@@ -3,6 +3,7 @@ import { toNestErrors } from '../toNestErrors';
 
 const flatObject: Record<string, FieldError> = {
   name: { type: 'st', message: 'first message' },
+  'name.firstName': { type: 'rd', message: 'third message' },
   'test.0.name': { type: 'nd', message: 'second message' },
 };
 

--- a/src/toNestErrors.ts
+++ b/src/toNestErrors.ts
@@ -14,24 +14,28 @@ export const toNestErrors = <TFieldValues extends FieldValues>(
   options: ResolverOptions<TFieldValues>,
 ): FieldErrors<TFieldValues> => {
   options.shouldUseNativeValidation && validateFieldsNatively(errors, options);
-
   const fieldErrors = {} as FieldErrors<TFieldValues>;
   for (const path in errors) {
     const field = get(options.fields, path) as Field['_f'] | undefined;
-    const error = Object.assign(errors[path] || {}, {
-      ref: field && field.ref,
-    });
-
     if (isNameInFieldArray(options.names || Object.keys(errors), path)) {
-      const fieldArrayErrors = Object.assign({}, get(fieldErrors, path));
-
+      const fieldArrayErrors = Object.assign(
+        {},
+        structuredClone(get(fieldErrors, path)),
+      );
+      const error = Object.assign(structuredClone(errors[path]) || {}, {
+        ref: field && field.ref,
+      });
       set(fieldArrayErrors, 'root', error);
       set(fieldErrors, path, fieldArrayErrors);
     } else {
+      const error = Object.assign(
+        structuredClone(errors[path]) || {},
+        structuredClone(get(fieldErrors, path)),
+        { ref: field && field.ref },
+      );
       set(fieldErrors, path, error);
     }
   }
-
   return fieldErrors;
 };
 

--- a/src/toNestErrors.ts
+++ b/src/toNestErrors.ts
@@ -20,17 +20,17 @@ export const toNestErrors = <TFieldValues extends FieldValues>(
     if (isNameInFieldArray(options.names || Object.keys(errors), path)) {
       const fieldArrayErrors = Object.assign(
         {},
-        structuredClone(get(fieldErrors, path)),
+        get(fieldErrors, path),
       );
-      const error = Object.assign(structuredClone(errors[path]) || {}, {
+      const error = Object.assign(errors[path] || {}, {
         ref: field && field.ref,
       });
       set(fieldArrayErrors, 'root', error);
       set(fieldErrors, path, fieldArrayErrors);
     } else {
       const error = Object.assign(
-        structuredClone(errors[path]) || {},
-        structuredClone(get(fieldErrors, path)),
+        errors[path] || {},
+        get(fieldErrors, path) || {},
         { ref: field && field.ref },
       );
       set(fieldErrors, path, error);


### PR DESCRIPTION
This fixes a nesting issue I've originally hit with the ajv resolver (albeit the issue itself is applicable to all resolvers) which is that `toNestErrors` may lose keys depending on the order of the keys returned by the `parseErrorSchema`, e.g. in this particular example the error for the `config` is actually last (the console output of `parsedErrors` is sorted thus a bit misleading) and simply replaces the `config: { type: …, userId: … }` object that existed one nesting step earlier —

<img width="2048" height="687" alt="image" src="https://github.com/user-attachments/assets/430eb48f-c843-410b-8bae-4a24dc54882b" />

I was explaining this to my coworkers so I have a screencast (100 seconds) that illustrates the issue, attaching it here in hope that it'd explain the changes behind the PR better than my writing —

https://github.com/user-attachments/assets/2e5eb038-3e73-434b-bb49-1a54a30747cd

Also I was not very comfortable with passing the objects straight to `Object.assign`, I think I've hit a bug with objects being mutated in place, so even though I can no longer reproduce it I've still wrapped "foreign" objects in a `structuredClone`, just to be on a safe side.