### PR TITLE
Change test command from 'bun test' to 'bun run test'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Here is a quick guide to doing code contributions to the library.
 
 4. If you've added a code that should be tested, ensure the test suite still passes.
 
-   > bun test
+   > bun run test
 
 5. Try to write some unit tests to cover as much of your code as possible.
 


### PR DESCRIPTION
Updated test command in contributing guidelines.

`bun test` runs [Bun Test](https://bun.sh/docs/test/configuration) unsuccessfully.

`bun run test` runs Vitest as expected.
