### PR TITLE
README: Add guidance on passing context to `yupResolver` (useForm context)

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Dead simple Object schema validation.
 
 [![npm](https://img.shields.io/bundlephobia/minzip/yup?style=for-the-badge)](https://bundlephobia.com/result?p=yup)
 
-> ⚠️ Pass context via `useForm({ context })`, not via `yupResolver`'s `schemaOptions`. Using React state/atoms via `schemaOptions.context` can result in stale/undefined values.
+> ⚠️ Pass context via `useForm({ context })`, not via `yupResolver`'s `schemaOptions`. Using React state/atoms via `schemaOptions.context` can result in `undefined` values.
 
 ```typescript jsx
 // Correct

--- a/README.md
+++ b/README.md
@@ -147,6 +147,19 @@ Dead simple Object schema validation.
 
 [![npm](https://img.shields.io/bundlephobia/minzip/yup?style=for-the-badge)](https://bundlephobia.com/result?p=yup)
 
+> ⚠️ Pass context via `useForm({ context })`, not via `yupResolver`'s `schemaOptions`. Using React state/atoms via `schemaOptions.context` can result in stale/undefined values.
+
+```typescript jsx
+// Correct
+useForm({
+  resolver: yupResolver(schema),
+  context: { foo: true },
+});
+
+// Avoid - context will be stale/undefined
+yupResolver(schema, { context: { foo: true } });
+```
+
 ```typescript jsx
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Dead simple Object schema validation.
 
 [![npm](https://img.shields.io/bundlephobia/minzip/yup?style=for-the-badge)](https://bundlephobia.com/result?p=yup)
 
-> ⚠️ Pass context via `useForm({ context })`, not via `yupResolver`'s `schemaOptions`. Using React state/atoms via `schemaOptions.context` can result in `undefined` values.
+> ⚠️ Pass context via `useForm({ context })`, not via `yupResolver`'s `schemaOptions`. `schemaOptions.context` is overridden by the form context, so use the `useForm` context object instead.
 
 ```typescript jsx
 // Correct
@@ -156,7 +156,7 @@ useForm({
   context: { foo: true },
 });
 
-// Avoid - context will be stale/undefined
+// Avoid - schemaOptions.context will be ignored/overridden
 yupResolver(schema, { context: { foo: true } });
 ```
 


### PR DESCRIPTION
## Reason for change

Yup typically uses the `schema.validate(values, { context })` pattern, which naturally leads users to try `yupResolver(schema, { context })`. However, yupResolver in `@hookform/resolvers` does not recommend using `schemaOptions.context` and overrides it with the form context provided by `useForm({ context })` (there is a dev warning in the code), and this is not clearly documented in the README. This can increase debugging cost for users.

## What’s changed

- Added a short explanation in the Yup section of the README on how to pass context.
- Clarified that context should be provided via `useForm({ context })`, and that this value is injected into Yup’s validation context at resolver execution time, with an example.
- Briefly clarified that `schemaOptions.context` is overridden by the form context, so context should be passed via `useForm({ context })` instead.

## Scope of impact
- Documentation-only change (no behavior changes).

## References
- Dev warning inside yup resolver: https://github.com/react-hook-form/resolvers/blob/2e9bc7c7d02506d336e20d8c0bae0c479f3662ec/yup/src/yup.ts#L100
- fixes: https://github.com/react-hook-form/resolvers/issues/834