### PR TITLE
ci: updated publish workflow to use node 24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
 
       - name: Setup bun
         uses: oven-sh/setup-bun@v1


### PR DESCRIPTION
This commit updates from Node 20 to Node 24. Semantic Release [version 25](https://github.com/semantic-release/semantic-release/releases/tag/v25.0.0) has a breaking change and drops support for node 20:

>node-versions: drop support for node versions v20, v21, and v23
node-versions: a minimum of node v22.14 is now required

This causes publishing in CI to fail with the error "[semantic-release]: node version ^22.14.0 || >= 24.10.0 is required. Found v20.19.5."

This fixes https://github.com/react-hook-form/resolvers/issues/836.