### PR TITLE
fix(zod): relax zod v4 resolver overload typing

### DIFF
--- a/zod/src/__tests__/zod-v4-mini.ts
+++ b/zod/src/__tests__/zod-v4-mini.ts
@@ -111,6 +111,23 @@ describe('zodResolver', () => {
     >();
   });
 
+  it('should infer resolver types from a Zod v4 mini structural schema type', () => {
+    type StructuralSchema = {
+      _zod: {
+        input: { id: number };
+        output: { id: string };
+      };
+    };
+
+    type InferredResolver = ReturnType<
+      typeof zodResolver<unknown, StructuralSchema>
+    >;
+
+    expectTypeOf<InferredResolver>().toEqualTypeOf<
+      Resolver<{ id: number }, unknown, { id: string }>
+    >();
+  });
+
   it('should correctly infer the output type from a zod schema using a transform', () => {
     const resolver = zodResolver(
       z.object({

--- a/zod/src/__tests__/zod-v4.ts
+++ b/zod/src/__tests__/zod-v4.ts
@@ -118,6 +118,23 @@ describe('zodResolver', () => {
     >();
   });
 
+  it('should infer resolver types from a Zod v4 structural schema type', () => {
+    type StructuralSchema = {
+      _zod: {
+        input: { id: number };
+        output: { id: string };
+      };
+    };
+
+    type InferredResolver = ReturnType<
+      typeof zodResolver<unknown, StructuralSchema>
+    >;
+
+    expectTypeOf<InferredResolver>().toEqualTypeOf<
+      Resolver<{ id: number }, unknown, { id: string }>
+    >();
+  });
+
   it('should correctly infer the output type from a zod schema using a transform', () => {
     const resolver = zodResolver(
       z.object({ id: z.number().transform((val) => String(val)) }),

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -221,28 +221,17 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
   resolverOptions: RawResolverOptions,
 ): Resolver<Input, Context, Input>;
 // the Zod 4 overloads need to be generic for complicated reasons
-export function zodResolver<
-  Context,
-  T extends Zod4TypeLike,
->(
+export function zodResolver<Context, T extends Zod4TypeLike>(
   schema: T,
   schemaOptions?: Zod4ParseParams, // already partial
   resolverOptions?: NonRawResolverOptions,
 ): Resolver<Zod4Input<T>, Context, Zod4Output<T>>;
-export function zodResolver<
-  Input extends FieldValues,
-  Context,
-  Output,
->(
+export function zodResolver<Input extends FieldValues, Context, Output>(
   schema: Zod4SchemaLike<Input, Output>,
   schemaOptions?: Zod4ParseParams, // already partial
   resolverOptions?: NonRawResolverOptions,
 ): Resolver<Input, Context, Output>;
-export function zodResolver<
-  Input extends FieldValues,
-  Context,
-  Output,
->(
+export function zodResolver<Input extends FieldValues, Context, Output>(
   schema: Zod4SchemaLike<Input, Output>,
   schemaOptions: Zod4ParseParams | undefined, // already partial
   resolverOptions: RawResolverOptions,

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -148,6 +148,30 @@ interface Zod3Type<O = unknown, I = unknown> {
     typeName: string;
   };
 }
+type Zod4TypeLike = {
+  _zod: {
+    input?: unknown;
+    output?: unknown;
+  };
+};
+type Zod4SchemaLike<Input = FieldValues, Output = unknown> = {
+  _zod: {
+    input: Input;
+    output: Output;
+  };
+};
+type Zod4Input<T extends Zod4TypeLike> = T extends {
+  _zod: { input?: infer I };
+}
+  ? I extends FieldValues
+    ? I
+    : FieldValues
+  : FieldValues;
+type Zod4Output<T extends Zod4TypeLike> = T extends {
+  _zod: { output?: infer O };
+}
+  ? O
+  : unknown;
 
 // some type magic to make versions pre-3.25.0 still work
 type IsUnresolved<T> = PropertyKey extends keyof T ? true : false;
@@ -198,25 +222,31 @@ export function zodResolver<Input extends FieldValues, Context, Output>(
 ): Resolver<Input, Context, Input>;
 // the Zod 4 overloads need to be generic for complicated reasons
 export function zodResolver<
-  Input extends FieldValues,
   Context,
-  Output,
-  T extends z4.$ZodType<Output, Input> = z4.$ZodType<Output, Input>,
+  T extends Zod4TypeLike,
 >(
   schema: T,
   schemaOptions?: Zod4ParseParams, // already partial
   resolverOptions?: NonRawResolverOptions,
-): Resolver<z4.input<T>, Context, z4.output<T>>;
+): Resolver<Zod4Input<T>, Context, Zod4Output<T>>;
 export function zodResolver<
   Input extends FieldValues,
   Context,
   Output,
-  T extends z4.$ZodType<Output, Input> = z4.$ZodType<Output, Input>,
 >(
-  schema: z4.$ZodType<Output, Input>,
+  schema: Zod4SchemaLike<Input, Output>,
+  schemaOptions?: Zod4ParseParams, // already partial
+  resolverOptions?: NonRawResolverOptions,
+): Resolver<Input, Context, Output>;
+export function zodResolver<
+  Input extends FieldValues,
+  Context,
+  Output,
+>(
+  schema: Zod4SchemaLike<Input, Output>,
   schemaOptions: Zod4ParseParams | undefined, // already partial
   resolverOptions: RawResolverOptions,
-): Resolver<z4.input<T>, Context, z4.input<T>>;
+): Resolver<Input, Context, Input>;
 /**
  * Creates a resolver function for react-hook-form that validates form data using a Zod schema
  * @param {z3.ZodSchema<Input>} schema - The Zod schema used to validate the form data


### PR DESCRIPTION
## Proposed Changes

- Replace strict Zod v4 overload constraints based on `$ZodType` internals with structural `_zod`-based typing.
- Preserve explicit generic usage (`<Input, Context, Output>`) while improving compatibility for mixed zod dependency trees.
- Keep raw/non-raw resolver return typing behavior unchanged.
- Add focused type-level tests for Zod v4 and v4-mini to lock structural overload inference.

