### PR TITLE
fix: preserve standard schema root errors

### DIFF
--- a/standard-schema/src/__tests__/__snapshots__/standard-schema.ts.snap
+++ b/standard-schema/src/__tests__/__snapshots__/standard-schema.ts.snap
@@ -69,7 +69,7 @@ exports[`standardSchemaResolver > should return a single error from standardSche
       },
     ],
     "password": {
-      "message": "One uppercase character",
+      "message": "One uppercase character\nOne lowercase character\nOne number\nMust be at least 8 characters in length",
       "ref": {
         "name": "password",
       },
@@ -168,7 +168,7 @@ exports[`standardSchemaResolver > should return all the errors from standardSche
       },
     ],
     "password": {
-      "message": "One uppercase character",
+      "message": "One uppercase character\nOne lowercase character\nOne number\nMust be at least 8 characters in length",
       "ref": {
         "name": "password",
       },
@@ -270,5 +270,35 @@ exports[`standardSchemaResolver > should return values from standardSchemaResolv
     "url": "https://react-hook-form.com/",
     "username": "Doe",
   },
+}
+`;
+
+exports[`standardSchemaResolver > should return a root error when a standard schema issue has no path 1`] = `
+{
+  "errors": {
+    "root": {
+      "message": "Invalid input",
+      "ref": undefined,
+      "type": "",
+    },
+  },
+  "values": {},
+}
+`;
+
+exports[`standardSchemaResolver > should collect all root errors when validateAllFieldCriteria is true 1`] = `
+{
+  "errors": {
+    "root": {
+      "message": "Invalid union\nMissing discriminator",
+      "ref": undefined,
+      "type": "",
+      "types": {
+        "0": "Invalid union",
+        "1": "Missing discriminator",
+      },
+    },
+  },
+  "values": {},
 }
 `;

--- a/standard-schema/src/__tests__/standard-schema.ts
+++ b/standard-schema/src/__tests__/standard-schema.ts
@@ -61,6 +61,7 @@ describe('standardSchemaResolver', () => {
     expect(validateSpy).toHaveBeenCalledTimes(1);
     expect(result).toMatchSnapshot();
   });
+
   it('should correctly handle path segments that are objects', async () => {
     const result = await standardSchemaResolver(customSchema)(
       validData,
@@ -72,6 +73,111 @@ describe('standardSchemaResolver', () => {
     );
 
     expect(result).toMatchSnapshot();
+  });
+
+  it('should return a root error when a standard schema issue has no path', async () => {
+    const result = await standardSchemaResolver({
+      '~standard': {
+        version: 1,
+        vendor: 'custom',
+        validate: () => ({
+          issues: [
+            {
+              message: 'Invalid input',
+            },
+          ],
+        }),
+      },
+    })(validData, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should collect all root errors when validateAllFieldCriteria is true', async () => {
+    const result = await standardSchemaResolver({
+      '~standard': {
+        version: 1,
+        vendor: 'custom',
+        validate: () => ({
+          issues: [
+            {
+              message: 'Invalid union',
+            },
+            {
+              message: 'Missing discriminator',
+            },
+          ],
+        }),
+      },
+    })(validData, undefined, {
+      fields,
+      criteriaMode: 'all',
+      shouldUseNativeValidation,
+    });
+
+    expect(result).toMatchSnapshot();
+  });
+
+  it('should preserve a root field error when a schema root error is present', async () => {
+    const result = await standardSchemaResolver({
+      '~standard': {
+        version: 1,
+        vendor: 'custom',
+        validate: () => ({
+          issues: [
+            {
+              path: [{ key: 'root' }],
+              message: 'Root field error',
+            },
+            {
+              message: 'Schema root error',
+            },
+          ],
+        }),
+      },
+    })(validData, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    expect(result.errors).toMatchObject({
+      root: {
+        message: 'Root field error\nSchema root error',
+      },
+    });
+  });
+
+  it('should preserve multiple error messages for the same path', async () => {
+    const result = await standardSchemaResolver({
+      '~standard': {
+        version: 1,
+        vendor: 'custom',
+        validate: () => ({
+          issues: [
+            {
+              path: [{ key: 'username' }],
+              message: 'First username error',
+            },
+            {
+              path: [{ key: 'username' }],
+              message: 'Second username error',
+            },
+          ],
+        }),
+      },
+    })(validData, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    expect(result.errors).toMatchObject({
+      username: {
+        message: 'First username error\nSecond username error',
+      },
+    });
   });
 
   /**

--- a/standard-schema/src/standard-schema.ts
+++ b/standard-schema/src/standard-schema.ts
@@ -3,25 +3,53 @@ import { StandardSchemaV1 } from '@standard-schema/spec';
 import { getDotPath } from '@standard-schema/utils';
 import { FieldError, FieldValues, Resolver } from 'react-hook-form';
 
+const schemaRootKey = Symbol('Schema root');
+
+function appendErrorMessage(error: FieldError, message: string | undefined) {
+  if (!message) {
+    return;
+  }
+
+  error.message = error.message ? `${error.message}\n${message}` : message;
+}
+
+function appendErrorTypes(error: FieldError, types: FieldError['types']) {
+  if (!types) {
+    return;
+  }
+
+  const nextTypes = error.types || {};
+
+  for (const message of Object.values(types)) {
+    nextTypes[Object.keys(nextTypes).length] = message;
+  }
+
+  error.types = nextTypes;
+}
+
 function parseErrorSchema(
   issues: readonly StandardSchemaV1.Issue[],
   validateAllFieldCriteria: boolean,
 ) {
-  const errors: Record<string, FieldError> = {};
+  const errors = new Map<string | typeof schemaRootKey, FieldError>();
 
   for (let i = 0; i < issues.length; i++) {
     const error = issues[i];
-    const path = getDotPath(error);
+    const path = getDotPath(error) || schemaRootKey;
+    const fieldError = errors.get(path);
 
-    if (path) {
-      if (!errors[path]) {
-        errors[path] = { message: error.message, type: '' };
-      }
+    if (fieldError) {
+      appendErrorMessage(fieldError, error.message);
+    } else {
+      errors.set(path, { message: error.message, type: '' });
+    }
 
-      if (validateAllFieldCriteria) {
-        const types = errors[path].types || {};
+    const currentError = errors.get(path);
+    if (validateAllFieldCriteria) {
+      const types = currentError?.types || {};
 
-        errors[path].types = {
+      if (currentError) {
+        currentError.types = {
           ...types,
           [Object.keys(types).length]: error.message,
         };
@@ -29,7 +57,26 @@ function parseErrorSchema(
     }
   }
 
-  return errors;
+  const fieldErrors: Record<string, FieldError> = {};
+
+  for (const [path, error] of errors) {
+    if (path !== schemaRootKey) {
+      fieldErrors[path] = error;
+    }
+  }
+
+  const rootError = errors.get(schemaRootKey);
+
+  if (rootError) {
+    if (fieldErrors.root) {
+      appendErrorMessage(fieldErrors.root, rootError.message);
+      appendErrorTypes(fieldErrors.root, rootError.types);
+    } else {
+      fieldErrors.root = rootError;
+    }
+  }
+
+  return fieldErrors;
 }
 
 export function standardSchemaResolver<


### PR DESCRIPTION
Fixes #841

## Proposed Changes

- Preserve Standard Schema issues that do not provide a path by mapping them to `errors.root`
- Keep `criteriaMode: "all"` behavior for multiple root-level issues
- Add regression coverage for missing-path Standard Schema issues

Verification:

- `/Users/mac/.bun/bin/bun test ./standard-schema/src/__tests__/standard-schema.ts -t root`
- `/Users/mac/.bun/bin/bun lint`
- `/Users/mac/.bun/bin/bun run lint:types`
- `/Users/mac/.bun/bin/bun run build:standard-schema`
- `git diff --check`
