### PR TITLE
fix #842 zodResolver() type overload fails with Zod v4.3.x due to branded version mismatch

### DIFF
--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -149,6 +149,16 @@ interface Zod3Type<O = unknown, I = unknown> {
   };
 }
 
+// minimal interface to avoid assignability issues between zod v4 patch/minor
+// releases, which brand the full `$ZodType` shape with an exact version literal
+// (e.g. `_zod.version.minor`)
+interface Zod4Type<Output = unknown, Input = unknown> {
+  _zod: {
+    output: Output;
+    input: Input;
+  };
+}
+
 // some type magic to make versions pre-3.25.0 still work
 type IsUnresolved<T> = PropertyKey extends keyof T ? true : false;
 type UnresolvedFallback<T, Fallback> = IsUnresolved<typeof z3> extends true
@@ -201,7 +211,7 @@ export function zodResolver<
   Input extends FieldValues,
   Context,
   Output,
-  T extends z4.$ZodType<Output, Input> = z4.$ZodType<Output, Input>,
+  T extends Zod4Type<Output, Input> = Zod4Type<Output, Input>,
 >(
   schema: T,
   schemaOptions?: Zod4ParseParams, // already partial
@@ -211,9 +221,9 @@ export function zodResolver<
   Input extends FieldValues,
   Context,
   Output,
-  T extends z4.$ZodType<Output, Input> = z4.$ZodType<Output, Input>,
+  T extends Zod4Type<Output, Input> = Zod4Type<Output, Input>,
 >(
-  schema: z4.$ZodType<Output, Input>,
+  schema: Zod4Type<Output, Input>,
   schemaOptions: Zod4ParseParams | undefined, // already partial
   resolverOptions: RawResolverOptions,
 ): Resolver<z4.input<T>, Context, z4.input<T>>;


### PR DESCRIPTION
…nded version mismatch