### PR TITLE
fix: AJV Resolver - When ajv schema contains default for certain properties, getValues() returns the form data with properties overwritten

### DIFF
--- a/ajv/src/__tests__/ajv.ts
+++ b/ajv/src/__tests__/ajv.ts
@@ -1,3 +1,4 @@
+import { JSONSchemaType } from 'ajv';
 import { ajvResolver } from '..';
 import {
   fields,
@@ -99,5 +100,44 @@ describe('ajvResolver', () => {
         },
       ),
     ).toMatchSnapshot();
+  });
+
+  it('should not mutate the input values object when `useDefaults` fills in missing properties (#647)', async () => {
+    interface DataWithDefaults {
+      user: { name: string; lastName: string };
+    }
+
+    const schemaWithDefaults: JSONSchemaType<DataWithDefaults> = {
+      type: 'object',
+      properties: {
+        user: {
+          type: 'object',
+          properties: {
+            name: { type: 'string', default: 'Camilo' },
+            lastName: { type: 'string', default: 'A random lastName' },
+          },
+          required: ['name', 'lastName'],
+        },
+      },
+      required: ['user'],
+    };
+
+    // Simulates react-hook-form's internal form values, which are passed
+    // into the resolver by reference and must not be mutated as a side
+    // effect of validation.
+    const formValues: Partial<DataWithDefaults> = { user: {} as any };
+
+    const result = await ajvResolver(schemaWithDefaults, {
+      useDefaults: true,
+    })(formValues as DataWithDefaults, undefined, {
+      fields,
+      shouldUseNativeValidation,
+    });
+
+    expect(formValues).toEqual({ user: {} });
+    expect(result).toEqual({
+      values: { user: { name: 'Camilo', lastName: 'A random lastName' } },
+      errors: {},
+    });
   });
 });

--- a/ajv/src/ajv.ts
+++ b/ajv/src/ajv.ts
@@ -103,12 +103,17 @@ export const ajvResolver: Resolver =
       ),
     );
 
-    const valid = validate(values);
+    // Ajv mutates the object passed to `validate` in place (e.g. to apply
+    // `useDefaults`, `removeAdditional`, or `coerceTypes`). Validating a
+    // clone keeps those mutations from leaking into react-hook-form's
+    // internal form values, which are passed in by reference.
+    const parsedValues = structuredClone(values);
+    const valid = validate(parsedValues);
 
     options.shouldUseNativeValidation && validateFieldsNatively({}, options);
 
     return valid
-      ? { values, errors: {} }
+      ? { values: parsedValues, errors: {} }
       : {
           values: {},
           errors: toNestErrors(


### PR DESCRIPTION
close #647