### PR TITLE
fix: Zod resolver drops validation errors for special root field names

### DIFF
--- a/zod/src/__tests__/special-path-names.ts
+++ b/zod/src/__tests__/special-path-names.ts
@@ -1,0 +1,55 @@
+import { z as z3 } from 'zod/v3';
+import { z as z4 } from 'zod/v4';
+import { zodResolver } from '..';
+
+const shouldUseNativeValidation = false;
+
+describe.each([
+  { version: 'v3', z: z3 as unknown as typeof z4 },
+  { version: 'v4', z: z4 },
+])('zodResolver special path names ($version)', ({ z }) => {
+  // These names are inherited (truthy) members of `Object.prototype`, so a
+  // resolver that tracks seen paths via a plain `{}` map and `!errors[path]`
+  // would treat them as "already recorded" and drop the real error.
+  it.each(['toString', 'hasOwnProperty'])(
+    'reports a validation error for a field named "%s"',
+    async (name) => {
+      const schema = z.object({ [name]: z.string().min(1) });
+
+      const direct = schema.safeParse({ [name]: '' });
+      expect(direct.success).toBe(false);
+
+      const result = await zodResolver(schema)(
+        { [name]: '' } as any,
+        undefined,
+        { fields: {}, shouldUseNativeValidation } as any,
+      );
+
+      expect(result.errors[name]).toMatchObject({ type: 'too_small' });
+    },
+  );
+
+  // `__proto__`, `constructor`, and `prototype` are also inherited/special
+  // members, but even once the resolver stops mis-tracking them internally,
+  // react-hook-form's own `set`/`get` helpers refuse to write those path
+  // segments at all (they hard-code them as a protected-path list to guard
+  // against prototype pollution). So these remain dropped end-to-end — that
+  // part of the behavior lives in react-hook-form, not in this resolver.
+  it.each(['__proto__', 'constructor', 'prototype'])(
+    'still drops a field named "%s" (react-hook-form protected path)',
+    async (name) => {
+      const schema = z.object({ [name]: z.string().min(1) });
+
+      const direct = schema.safeParse({ [name]: '' });
+      expect(direct.success).toBe(false);
+
+      const result = await zodResolver(schema)(
+        { [name]: '' } as any,
+        undefined,
+        { fields: {}, shouldUseNativeValidation } as any,
+      );
+
+      expect(result.errors).toEqual({});
+    },
+  );
+});

--- a/zod/src/zod.ts
+++ b/zod/src/zod.ts
@@ -41,7 +41,11 @@ function parseZod3Issues(
   zodErrors: z3.ZodIssue[],
   validateAllFieldCriteria: boolean,
 ) {
-  const errors: Record<string, FieldError> = {};
+  // A null-prototype object avoids false-positive hits from inherited
+  // members (e.g. `toString`, `constructor`, `__proto__`) when a field is
+  // named after one of them — a plain `{}` would make `!errors[_path]`
+  // truthy-skip those paths and silently drop their errors.
+  const errors: Record<string, FieldError> = Object.create(null);
   for (; zodErrors.length; ) {
     const error = zodErrors[0];
     const { code, message, path } = error;
@@ -101,7 +105,8 @@ function parseZod4Issues(
   zodErrors: z4.$ZodIssue[],
   validateAllFieldCriteria: boolean,
 ) {
-  const errors: Record<string, FieldError> = {};
+  // See the matching comment in `parseZod3Issues` above.
+  const errors: Record<string, FieldError> = Object.create(null);
   // const _zodErrors = zodErrors as z4.$ZodISsue; //
   for (; zodErrors.length; ) {
     const error = zodErrors[0];


### PR DESCRIPTION
thanks to @joostgrunwald for the report 🙏 